### PR TITLE
Allow the user to specify a maximum drive speed when ripping

### DIFF
--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -244,7 +244,7 @@ Log files will log the path to tracks relative to this directory.
                 default_maxspeed = config.Config().getMaxReadSpeed(*info)
                 sys.stdout.write("Using configured maximum read speed %d\n" %
                                  default_maxspeed)
-            
+
             except KeyError:
                 pass
 

--- a/whipper/command/drive.py
+++ b/whipper/command/drive.py
@@ -103,6 +103,16 @@ class List(BaseCommand):
                                  "Run 'whipper offset find'\n")
 
             try:
+                maxspeed = self.config.getMaxReadSpeed(
+                    vendor, model, release)
+                sys.stdout.write("       "
+                                 "Maximum drive speed throttled to: %dx\n"
+                                 % maxspeed)
+            except KeyError:
+                sys.stdout.write("       "
+                                 "No maximum drive speed configured.\n")
+
+            try:
                 defeats = self.config.getDefeatsCache(
                     vendor, model, release)
                 sys.stdout.write(

--- a/whipper/command/offset.py
+++ b/whipper/command/offset.py
@@ -188,6 +188,7 @@ CD in the AccurateRip database."""
         t = cdparanoia.ReadTrackTask(path, table,
                                      table.getTrackStart(
                                          track), table.getTrackEnd(track),
+                                     maxspeed=None,
                                      overread=False, offset=offset,
                                      device=self.options.device)
         t.description = 'Ripping track %d with read offset %d' % (

--- a/whipper/common/common.py
+++ b/whipper/common/common.py
@@ -35,7 +35,8 @@ SAMPLES_PER_FRAME = 588  # a sample is 2 16-bit values, left and right channel
 WORDS_PER_FRAME = SAMPLES_PER_FRAME * 2
 BYTES_PER_FRAME = SAMPLES_PER_FRAME * 4
 
-BYTES_PER_SECOND_CDROM_X1 = 153600 # Data access rate of a single-speed CD-ROM
+BYTES_PER_SECOND_CDROM_X1 = 153600  # Data access rate of a single-speed CD-ROM
+
 
 class EjectError(SystemError):
     """Possibly ejects the drive in command.main.

--- a/whipper/common/common.py
+++ b/whipper/common/common.py
@@ -35,6 +35,7 @@ SAMPLES_PER_FRAME = 588  # a sample is 2 16-bit values, left and right channel
 WORDS_PER_FRAME = SAMPLES_PER_FRAME * 2
 BYTES_PER_FRAME = SAMPLES_PER_FRAME * 4
 
+BYTES_PER_SECOND_CDROM_X1 = 153600 # Data access rate of a single-speed CD-ROM
 
 class EjectError(SystemError):
     """Possibly ejects the drive in command.main.

--- a/whipper/common/config.py
+++ b/whipper/common/config.py
@@ -118,9 +118,9 @@ class Config:
     def getMaxReadSpeed(self, vendor, model, release):
         """Get a maximum read speed for the given drive.
 
-        :param vendor:
-        :param model:
-        :param release:
+        :param vendor:  Drive vendor
+        :param model:   Drive model
+        :param release: Drive release (or firmware)
 
         """
         section = self._findDriveSection(vendor, model, release)

--- a/whipper/common/config.py
+++ b/whipper/common/config.py
@@ -89,10 +89,10 @@ class Config:
 
         Strips the given strings of leading and trailing whitespace.
 
-        :param vendor:
-        :param model:
-        :param release:
-        :param offset:
+        :param vendor:  Drive vendor
+        :param model:   Drive model
+        :param release: Drive release (or firmware)
+        :param offset:  Drive read offset
 
         """
         section = self._findOrCreateDriveSection(vendor, model, release)
@@ -102,9 +102,9 @@ class Config:
     def getReadOffset(self, vendor, model, release):
         """Get a read offset for the given drive.
 
-        :param vendor:
-        :param model:
-        :param release:
+        :param vendor:  Drive vendor
+        :param model:   Drive model
+        :param release: Drive release (or firmware)
 
         """
         section = self._findDriveSection(vendor, model, release)
@@ -113,6 +113,22 @@ class Config:
             return int(self._parser.get(section, 'read_offset'))
         except ConfigParser.NoOptionError:
             raise KeyError("Could not find read_offset for %s/%s/%s" % (
+                vendor, model, release))
+
+    def getMaxReadSpeed(self, vendor, model, release):
+        """Get a maximum read speed for the given drive.
+
+        :param vendor:
+        :param model:
+        :param release:
+
+        """
+        section = self._findDriveSection(vendor, model, release)
+
+        try:
+            return int(self._parser.get(section, 'max_read_speed'))
+        except ConfigParser.NoOptionError:
+            raise KeyError("Could not find max_read_speed for %s/%s/%s" % (
                 vendor, model, release))
 
     def setDefeatsCache(self, vendor, model, release, defeat):

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -549,7 +549,7 @@ class Program:
                      trackResult.testcrc, t.checksum, ret)
         return ret
 
-    def ripTrack(self, runner, trackResult, offset, device, taglist,
+    def ripTrack(self, runner, trackResult, maxspeed, offset, device, taglist,
                  overread, what=None):
         """.
 
@@ -560,6 +560,8 @@ class Program:
         :type trackResult: L{result.TrackResult}
         :param runner:
         :type runner:
+        :param maxspeed: throttle drive to specified read speed
+        :type maxspeed:
         :param offset:
         :type offset:
         :param device:
@@ -586,7 +588,9 @@ class Program:
 
         t = cdparanoia.ReadVerifyTrackTask(trackResult.filename,
                                            self.result.table, start,
-                                           stop, overread,
+                                           stop,
+                                           overread=overread,
+                                           maxspeed=maxspeed,
                                            offset=offset,
                                            device=device,
                                            taglist=taglist,

--- a/whipper/result/logger.py
+++ b/whipper/result/logger.py
@@ -215,7 +215,7 @@ class WhipperLogger(result.Logger):
         if trackResult.copyspeed:
             lines.append("    Extraction speed: %.1f X" % (
                 trackResult.copyspeed))
-                
+
         # Extraction quality
         if trackResult.quality and trackResult.quality > 0.001:
             lines.append("    Extraction quality: %.2f %%" %

--- a/whipper/result/logger.py
+++ b/whipper/result/logger.py
@@ -51,6 +51,13 @@ class WhipperLogger(result.Logger):
         lines.append("Ripping phase information:")
         lines.append("  Drive: %s%s (revision %s)" % (
             ripResult.vendor, ripResult.model, ripResult.release))
+
+        if ripResult.maxspeed is None:
+            throttling = "No"
+        else:
+            throttling = "%sx speed" % ripResult.maxspeed
+        lines.append("  Drive speed throttled: %s" % throttling)
+
         if ripResult.cdparanoiaDefeatsCache is None:
             defeat = "Unknown"
         elif ripResult.cdparanoiaDefeatsCache:
@@ -208,7 +215,7 @@ class WhipperLogger(result.Logger):
         if trackResult.copyspeed:
             lines.append("    Extraction speed: %.1f X" % (
                 trackResult.copyspeed))
-
+                
         # Extraction quality
         if trackResult.quality and trackResult.quality > 0.001:
             lines.append("    Extraction quality: %.2f %%" %

--- a/whipper/result/result.py
+++ b/whipper/result/result.py
@@ -72,6 +72,8 @@ class RipResult:
 
     :cvar offset: sample read offset.
     :vartype offset:
+    :cvar maxspeed: throttle drive to specified read speed
+    :vartype maxspeed:
     :cvar table: the full index table.
     :vartype table: L{whipper.image.table.Table}
     :cvar vendor: vendor of the CD drive.
@@ -88,6 +90,7 @@ class RipResult:
 
     offset = 0
     overread = None
+    maxspeed = None
     isCdr = None
     logger = None
     table = None


### PR DESCRIPTION
Implements #204.

**Changed:**
 * Adds the command-line parameter `--speed` (or `-s`).
 * Adds `max_read_speed` as a per-drive setting in `whipper.conf`. If set, the value is reported when running `whipper drive list`.
 * Modified the calculation used to determine the speed of a rip. Previously, this was simply the duration of the track (in seconds) divided by the time taken to read it from disc (also in seconds). The speed is now calculated as multiples of cd-rom drive speeds [1]. This produces marginally different values from before, but is perhaps now more closely aligned with cd-paranoia's `--force-read-speed` option. I'm not precious about this change though, so feel free to revert.

**Unchanged:**
 * This setting is ignored when running `whipper offset find` - only when ripping / verifying. Is there any benefit to be had in throttling at this stage of the workflow?

**Notes:**
 * This speed value is passed through directly to cd-paranoia's `--force-read-speed` option. cd-paranoia only appears to allow integer values, but I haven't enforced this in my code.
 * This argument is only a *request* that the read speed is throttled - it will be ignored by cd-paranoia for some drive models.
 * I'm still new to python, so code review comments are welcomed. Most of this is copy/pasted from the existing code for the drive offset config, so hopefully it's not too broken.

[1] A single-speed cd-rom drive reads data at a rate of 153600 bytes per second, so speed can be calculated as: `.wav file size / (read time in seconds * 153600)`