### PR TITLE
Added whipper.debug.version commands for flac, sox and soxi, tidy-up.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ REVISION
 .project
 .pydevproject
 
+# For Python development using Visual Studio Code
+.vscode/
+
 # setup.py install generated files
 build/
 dist/

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -167,7 +167,7 @@ class _CD(BaseCommand):
 
         # result
 
-        self.program.result.cdrdaoVersion = cdrdao.getCDRDAOVersion()
+        self.program.result.cdrdaoVersion = cdrdao.getVersion()
         self.program.result.cdparanoiaVersion = \
             cdparanoia.getVersion()
         info = drive.getDeviceInfo(self.device)

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -169,7 +169,7 @@ class _CD(BaseCommand):
 
         self.program.result.cdrdaoVersion = cdrdao.getCDRDAOVersion()
         self.program.result.cdparanoiaVersion = \
-            cdparanoia.getCdParanoiaVersion()
+            cdparanoia.getVersion()
         info = drive.getDeviceInfo(self.device)
         if info:
             try:

--- a/whipper/command/debug.py
+++ b/whipper/command/debug.py
@@ -262,7 +262,7 @@ class CDParanoia(BaseCommand):
 
     def do(self):
         from whipper.program import cdparanoia
-        version = cdparanoia.getCdParanoiaVersion()
+        version = cdparanoia.getVersion()
         sys.stdout.write("cdparanoia version: %s\n" % version)
 
 
@@ -272,8 +272,38 @@ class CDRDAO(BaseCommand):
 
     def do(self):
         from whipper.program import cdrdao
-        version = cdrdao.getCDRDAOVersion()
+        version = cdrdao.getVersion()
         sys.stdout.write("cdrdao version: %s\n" % version)
+
+
+class Flac(BaseCommand):
+    summary = "show flac version"
+    description = summary
+
+    def do(self):
+        from whipper.program import flac
+        version = flac.getVersion()
+        sys.stdout.write("flac version: %s\n" % version)
+
+
+class Sox(BaseCommand):
+    summary = "show sox version"
+    description = summary
+
+    def do(self):
+        from whipper.program import sox
+        version = sox.getVersion()
+        sys.stdout.write("sox version: %s\n" % version)
+
+
+class Soxi(BaseCommand):
+    summary = "show soxi version"
+    description = summary
+
+    def do(self):
+        from whipper.program import soxi
+        version = soxi.getVersion()
+        sys.stdout.write("soxi version: %s\n" % version)
 
 
 class Version(BaseCommand):
@@ -283,6 +313,9 @@ class Version(BaseCommand):
     subcommands = {
         'cdparanoia': CDParanoia,
         'cdrdao': CDRDAO,
+        'flac': Flac,
+        'sox': Sox,
+        'soxi': Soxi,
     }
 
 

--- a/whipper/command/offset.py
+++ b/whipper/command/offset.py
@@ -87,7 +87,8 @@ CD in the AccurateRip database."""
         utils.unmount_device(device)
 
         # first get the Table Of Contents of the CD
-        t = cdrdao.ReadTOCTask(device)
+        t = cdrdao.read_toc(device, True)
+
         table = t.table
 
         logger.debug("CDDB disc id: %r", table.getCDDBDiscId())

--- a/whipper/common/checksum.py
+++ b/whipper/common/checksum.py
@@ -21,11 +21,11 @@
 import binascii
 import wave
 import tempfile
-import subprocess
 import os
 
 
 from whipper.extern.task import task as etask
+from whipper.program import flac
 
 import logging
 logger = logging.getLogger(__name__)
@@ -47,10 +47,10 @@ class CRC32Task(etask.Task):
 
     def _crc32(self):
         if not self.is_wave:
-            fd, tmpf = tempfile.mkstemp()
+            _, tmpf = tempfile.mkstemp()
 
             try:
-                subprocess.check_call(['flac', '-d', self.path, '-fo', tmpf])
+                flac.decode(self.path, tmpf)
 
                 w = wave.open(tmpf)
             finally:

--- a/whipper/common/common.py
+++ b/whipper/common/common.py
@@ -279,13 +279,16 @@ class VersionGetter(object):
     :ivar expander: the expansion string for the version using the
                      regexp group dict
     :vartype expander:
+    :ivar stderr: read result from standard error (otherwise stdout)
+    :vartype stderr: True if reading from stderr. False for stdout.
     """
 
-    def __init__(self, dependency, args, regexp, expander):
+    def __init__(self, dependency, args, regexp, expander, stderr=True):
         self._dep = dependency
         self._args = args
         self._regexp = regexp
         self._expander = expander
+        self._stderr = stderr
 
     def get(self):
         version = "(Unknown)"
@@ -295,7 +298,8 @@ class VersionGetter(object):
                                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE, close_fds=True)
             p.wait()
-            output = asyncsub.recv_some(p, e=0, stderr=1)
+            output = asyncsub.recv_some(p, e=0,
+                                        stderr=(1 if self._stderr else 0))
             vre = self._regexp.search(output)
             if vre:
                 version = self._expander % vre.groupdict()

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -114,13 +114,9 @@ class Program:
 
         ptoc = cache.Persister(toc_pickle or None)
         if not ptoc.object:
-            from pkg_resources import parse_version as V
-            version = cdrdao.getCDRDAOVersion()
-            if V(version) < V('1.2.3rc2'):
-                sys.stdout.write('Warning: cdrdao older than 1.2.3 has a '
-                                 'pre-gap length bug.\n'
-                                 'See http://sourceforge.net/tracker/?func=detail&aid=604751&group_id=2171&atid=102171\n')  # noqa: E501
-            t = cdrdao.ReadTOCTask(device)
+            sys.stdout.write(cdrdao.getVersionWarnings())
+
+            t = cdrdao.read_toc(device, fast_toc=True)
             ptoc.persist(t.table)
         toc = ptoc.object
         assert toc.hasTOC()
@@ -158,7 +154,7 @@ class Program:
             logger.debug('getTable: cddbdiscid %s, mbdiscid %s not '
                          'in cache for offset %s, reading table' % (
                              cddbdiscid, mbdiscid, offset))
-            t = cdrdao.ReadTableTask(device)
+            t = cdrdao.read_toc(device, fast_toc=False)
             itable = t.table
             tdict[offset] = itable
             ptable.persist(tdict)

--- a/whipper/extern/asyncsub.py
+++ b/whipper/extern/asyncsub.py
@@ -2,6 +2,7 @@
 # vi:si:et:sw=4:sts=4:ts=4
 
 # from http://code.activestate.com/recipes/440554/
+#      https://github.com/ActiveState/code/tree/master/recipes/Python/440554_Module_allow_Asynchronous_subprocess_use
 
 import os
 import subprocess

--- a/whipper/program/cdparanoia.py
+++ b/whipper/program/cdparanoia.py
@@ -35,6 +35,8 @@ from whipper.extern.task import task
 import logging
 logger = logging.getLogger(__name__)
 
+CDPARANOIA = "cd-paranoia"
+
 
 class FileSizeError(Exception):
     """The given path does not have the expected size."""
@@ -295,10 +297,10 @@ class ReadTrackTask(task.Task):
 
         bufsize = 1024
         if self._overread:
-            argv = ["cd-paranoia", "--stderr-progress",
+            argv = [CDPARANOIA, "--stderr-progress",
                     "--sample-offset=%d" % self._offset, "--force-overread", ]
         else:
-            argv = ["cd-paranoia", "--stderr-progress",
+            argv = [CDPARANOIA, "--stderr-progress",
                     "--sample-offset=%d" % self._offset, ]
         if self._device:
             argv.extend(["--force-cdrom-device", self._device, ])
@@ -574,15 +576,23 @@ class ReadVerifyTrackTask(task.MultiSeparateTask):
         task.MultiSeparateTask.stop(self)
 
 
+# Sample version string:
+# cdparanoia III release 10.2 (September 11, 2008)
 _VERSION_RE = re.compile(
     "^cdparanoia (?P<version>.+) release (?P<release>.+)")
 
 
-def getCdParanoiaVersion():
+def getVersion():
+    """Detect cd-paranoia's version.
+
+    :returns: Formatted cd-paranoia version string
+    :rtype: string
+    """
     getter = common.VersionGetter('cd-paranoia',
-                                  ["cd-paranoia", "-V"],
+                                  [CDPARANOIA, "-V"],
                                   _VERSION_RE,
-                                  "%(version)s %(release)s")
+                                  "%(version)s %(release)s",
+                                  stderr=True)
 
     return getter.get()
 
@@ -605,7 +615,7 @@ class AnalyzeTask(ctask.PopenTask):
     def __init__(self, device=None):
         # cdparanoia -A *always* writes cdparanoia.log
         self.cwd = tempfile.mkdtemp(suffix='.whipper.cache')
-        self.command = ['cd-paranoia', '-A']
+        self.command = [CDPARANOIA, '-A']
         if device:
             self.command += ['-d', device]
 

--- a/whipper/program/cdrdao.py
+++ b/whipper/program/cdrdao.py
@@ -93,32 +93,18 @@ def getVersion():
     return getter.get()
 
 
-def ReadTOCTask(device):
-    """Stopgap morituri-insanity compatibility layer.
+def getVersionWarnings():
+    """Display any warnings based upon the detected cdrdao version number.
 
-    :param device: optical disk drive.
-    :type device:
-    :returns:
-    :rtype: TocFile
+    :returns: Warning text specific to the detected CDRDAO version.
+    :rtype: string
     """
-    return read_toc(device, fast_toc=True)
 
-
-def ReadTableTask(device):
-    """Stopgap morituri-insanity compatibility layer.
-
-    :param device: optical disk drive.
-    :type device:
-    :returns:
-    :rtype: TocFile
-    """
-    return read_toc(device)
-
-
-def getCDRDAOVersion():
-    """Stopgap morituri-insanity compatibility layer.
-
-    :returns:
-    :rtype:
-    """
-    return getVersion()
+    from pkg_resources import parse_version as V
+    version = getVersion()
+    if V(version) < V('1.2.3rc2'):
+        return ('Warning: cdrdao older than 1.2.3 has a '
+                'pre-gap length bug.\n'
+                'See http://sourceforge.net/tracker/?func=detail&aid=604751&group_id=2171&atid=102171\n')  # noqa: E501
+    else:
+        return ''

--- a/whipper/program/flac.py
+++ b/whipper/program/flac.py
@@ -1,13 +1,19 @@
 from subprocess import check_call, CalledProcessError
+import re
+
+from whipper.common import common
 
 import logging
+
 logger = logging.getLogger(__name__)
+
+FLAC = 'flac'
 
 
 def encode(infile, outfile):
     """Encode infile to outfile, with flac.
 
-    Uses ``-f`` because whipper already creates the file.
+    Uses ``--force`` because whipper already creates the file.
 
     :param infile: full path to input audio track.
     :type infile: str
@@ -18,8 +24,49 @@ def encode(infile, outfile):
     try:
         # TODO: Replace with Popen so that we can catch stderr and write it to
         # logging
-        check_call(['flac', '--silent', '--verify', '-o', outfile,
-                    '-f', infile])
+        check_call([FLAC, '--silent', '--verify', '-o', outfile,
+                    '--force', infile])
     except CalledProcessError:
-        logger.exception('flac failed')
+        logger.exception('flac encode failed')
         raise
+
+
+def decode(infile, outfile):
+    """Decode infile to outfile, with flac.
+
+    Uses ``--force`` because whipper already creates the file.
+
+    :param infile: full path to input audio track.
+    :type infile: str
+    :param outfile: full path to output audio track.
+    :type outfile: str
+    :raises CalledProcessError: if the flac encoder returns non-zero.
+    """
+    try:
+        # TODO: Replace with Popen so that we can catch stderr and write it to
+        # logging
+        check_call([FLAC, '--silent', '--decode', '-o', outfile,
+                   '--force', infile])
+    except CalledProcessError:
+        logger.exception('flac decode failed')
+        raise
+
+
+# Sample version string:
+# flac 1.3.2
+_VERSION_RE = re.compile(
+    "^flac (?P<major>.+)\.(?P<minor>.+)\.(?P<micro>.+)")
+
+
+def getVersion():
+    """Detect flac's version.
+
+    :returns: Formatted flac version string
+    :rtype: string
+    """
+    getter = common.VersionGetter('flac',
+                                  [FLAC, "--version"],
+                                  _VERSION_RE,
+                                  "%(major)s.%(minor)s.%(micro)s",
+                                  stderr=False)
+    return getter.get()

--- a/whipper/program/sox.py
+++ b/whipper/program/sox.py
@@ -44,7 +44,7 @@ def getVersion():
     """Detect sox's version.
 
     :returns: Formatted sox version string
-    :rtype: bool
+    :rtype: string
     """
     getter = common.VersionGetter('sox',
                                   [SOX, "--version"],

--- a/whipper/program/sox.py
+++ b/whipper/program/sox.py
@@ -1,5 +1,8 @@
 import os
+import re
+
 from subprocess import Popen, PIPE
+from whipper.common import common
 
 import logging
 logger = logging.getLogger(__name__)
@@ -29,3 +32,23 @@ def peak_level(track_path):
     min_level = int(err.splitlines()[2].split()[2])
     max_level = int(err.splitlines()[3].split()[2])
     return max(abs(min_level), abs(max_level))
+
+
+# Sample version string:
+# sox:      SoX v14.4.2
+_VERSION_RE = re.compile(
+    "^sox:\s*SoX v(?P<major>.+)\.(?P<minor>.+)\.(?P<micro>.+)")
+
+
+def getVersion():
+    """Detect sox's version.
+
+    :returns: Formatted sox version string
+    :rtype: bool
+    """
+    getter = common.VersionGetter('sox',
+                                  [SOX, "--version"],
+                                  _VERSION_RE,
+                                  "%(major)s.%(minor)s.%(micro)s",
+                                  stderr=False)
+    return getter.get()

--- a/whipper/program/soxi.py
+++ b/whipper/program/soxi.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from whipper.common import common
 from whipper.common import task as ctask
@@ -58,3 +59,24 @@ class AudioLengthTask(ctask.PopenTask):
         if self._error:
             logger.warning("soxi reported on stderr: %s", "".join(self._error))
         self.length = int("".join(self._output))
+
+
+# Sample version string:
+# sox:      SoX v14.4.2
+_VERSION_RE = re.compile(
+    "^soxi:\s*SoX v(?P<major>.+)\.(?P<minor>.+)\.(?P<micro>.+)")
+
+
+def getVersion():
+    """Detect soxi's version.
+       Soxi doesn't have a --version command - we call it with no parameters.
+
+    :returns: Formatted soxi version string
+    :rtype: bool
+    """
+    getter = common.VersionGetter('soxi',
+                                  [SOXI],
+                                  _VERSION_RE,
+                                  "%(major)s.%(minor)s.%(micro)s",
+                                  stderr=False)
+    return getter.get()

--- a/whipper/program/soxi.py
+++ b/whipper/program/soxi.py
@@ -72,7 +72,7 @@ def getVersion():
        Soxi doesn't have a --version command - we call it with no parameters.
 
     :returns: Formatted soxi version string
-    :rtype: bool
+    :rtype: string
     """
     getter = common.VersionGetter('soxi',
                                   [SOXI],

--- a/whipper/test/test_program_cdparanoia.py
+++ b/whipper/test/test_program_cdparanoia.py
@@ -66,7 +66,7 @@ class ErrorTestCase(common.TestCase):
 class VersionTestCase(common.TestCase):
 
     def testGetVersion(self):
-        v = cdparanoia.getCdParanoiaVersion()
+        v = cdparanoia.getVersion()
         self.failUnless(v)
 
 

--- a/whipper/test/test_program_cdrdao.py
+++ b/whipper/test/test_program_cdrdao.py
@@ -14,9 +14,3 @@ class VersionTestCase(common.TestCase):
         self.failUnless(v)
         # make sure it starts with a digit
         self.failUnless(int(v[0]))
-
-    def testGetVersionLegacy(self):
-        v = cdrdao.getCDRDAOVersion()
-        self.failUnless(v)
-        # make sure it starts with a digit
-        self.failUnless(int(v[0]))

--- a/whipper/test/test_program_cdrdao.py
+++ b/whipper/test/test_program_cdrdao.py
@@ -8,7 +8,14 @@ from whipper.test import common
 
 
 class VersionTestCase(common.TestCase):
+
     def testGetVersion(self):
+        v = cdrdao.getVersion()
+        self.failUnless(v)
+        # make sure it starts with a digit
+        self.failUnless(int(v[0]))
+
+    def testGetVersionLegacy(self):
         v = cdrdao.getCDRDAOVersion()
         self.failUnless(v)
         # make sure it starts with a digit

--- a/whipper/test/test_program_flac.py
+++ b/whipper/test/test_program_flac.py
@@ -1,0 +1,13 @@
+# -*- Mode: Python; test-case-name: whipper.test.test_program_flac -*-
+
+from whipper.program import flac
+from whipper.test import common
+
+
+class VersionTestCase(common.TestCase):
+
+    def testGetVersion(self):
+        v = flac.getVersion()
+        self.failUnless(v)
+        # make sure it starts with a digit
+        self.failUnless(int(v[0]))

--- a/whipper/test/test_program_sox.py
+++ b/whipper/test/test_program_sox.py
@@ -12,3 +12,12 @@ class PeakLevelTestCase(common.TestCase):
 
     def testParse(self):
         self.assertEquals(26215, sox.peak_level(self.path))
+
+
+class VersionTestCase(common.TestCase):
+
+    def testGetVersion(self):
+        v = sox.getVersion()
+        self.failUnless(v)
+        # make sure it starts with a digit
+        self.failUnless(int(v[0]))

--- a/whipper/test/test_program_soxi.py
+++ b/whipper/test/test_program_soxi.py
@@ -5,6 +5,7 @@ import tempfile
 
 from whipper.common import common
 from whipper.extern.task import task
+from whipper.program import soxi
 from whipper.program.soxi import AudioLengthTask
 from whipper.test import common as tcommon
 
@@ -66,3 +67,12 @@ class AbsentFileAudioLengthPathTestCase(AudioLengthPathTestCase):
                           t, verbose=False)
 
         os.rmdir(tempdir)
+
+
+class VersionTestCase(tcommon.TestCase):
+
+    def testGetVersion(self):
+        v = soxi.getVersion()
+        self.failUnless(v)
+        # make sure it starts with a digit
+        self.failUnless(int(v[0]))


### PR DESCRIPTION
**Changed:**
 * Added `whipper debug version` commands for `flac`, `sox` and `soxi`.
 * Added a `stderr` flag to `VersionGetter` to accommodate tools which write to stdout (flac, sox, soxi) as well as those which write to stderr (cd-paranoia, cdrdao).
 * Update existing CDRDAO version method to use `VersionGetter`.
 * Added simple testcases for version checks.
 * Moved flac call from `checksum.py` into `program/flac.py`. Also silenced flac's banner text with `--silent`.

**Unchanged:**
 * `accuraterip-checksum` doesn't expose a version number, so remains unhandled.
 * `cdrdao.py` has 3 methods marked "_Stopgap morituri-insanity compatibility layer_" (including `getCDRDAOVersion`). Can these be safely replaced with the new versions?

**TODO:**
 * Calls to `flac` still use `check_call` - these should be moved over to use `popen`.
 * Consider adding timeouts to popen calls? (may have to wait for Python 3)