### PR TITLE
Set zero offset when running "cd rip info" #230

### DIFF
--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -207,6 +207,11 @@ class Info(_CD):
     def add_arguments(self):
         _CD.add_arguments(self.parser)
 
+    def handle_arguments(self):
+        sys.stdout.write("Ignoring read offset for reading CD info.\n")
+        self.options.offset = 0
+        _CD.handle_arguments(self)
+
 
 class Rip(_CD):
     summary = "rip CD"


### PR DESCRIPTION
Set a default offset of zero when running `whipper cd info`.

Not sure if this is the correct fix (do we care about offsets for `cd info`?), but it at least allows the command to complete, and doesn't seem to break `whipper cd rip`.