### PR TITLE
Add drive option to force using fast TOC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
 FROM debian:buster
 
 RUN apt-get update \
-  && apt-get install -y cdrdao git python-gobject-2 python-musicbrainzngs python-mutagen \
-  python-setuptools python-requests libsndfile1-dev flac sox \
-  libiso9660-dev python-pip swig make pkgconf \
-  eject locales \
-  autoconf libtool curl \
+  && apt-get install -y autoconf cdrdao curl eject flac git libiso9660-dev \
+  libsndfile1-dev libtool locales make pkgconf python-gobject-2 \
+  python-musicbrainzngs python-mutagen python-pip python-requests \
+  python-ruamel.yaml python-setuptools sox swig \
   && pip install pycdio==2.1.0
 
 # libcdio-paranoia / libcdio-utils are wrongfully packaged in Debian, thus built manually

--- a/whipper/common/config.py
+++ b/whipper/common/config.py
@@ -87,43 +87,23 @@ class Config:
     def setReadOffset(self, vendor, model, release, offset):
         """
         Set a read offset for the given drive.
-
-        Strips the given strings of leading and trailing whitespace.
         """
-        section = self._findOrCreateDriveSection(vendor, model, release)
-        self._parser.set(section, 'read_offset', str(offset))
-        self.write()
+        self._setDriveOption(vendor, model, release, 'read_offset', offset)
 
     def getReadOffset(self, vendor, model, release):
         """
         Get a read offset for the given drive.
         """
-        section = self._findDriveSection(vendor, model, release)
-
-        try:
-            return int(self._parser.get(section, 'read_offset'))
-        except ConfigParser.NoOptionError:
-            raise KeyError("Could not find read_offset for %s/%s/%s" % (
-                vendor, model, release))
+        return int(self._getDriveOption(vendor, model, release, 'read_offset'))
 
     def setDefeatsCache(self, vendor, model, release, defeat):
         """
         Set whether the drive defeats the cache.
-
-        Strips the given strings of leading and trailing whitespace.
         """
-        section = self._findOrCreateDriveSection(vendor, model, release)
-        self._parser.set(section, 'defeats_cache', str(defeat))
-        self.write()
+        self._setDriveOption(vendor, model, release, 'defeats_cache', defeat)
 
     def getDefeatsCache(self, vendor, model, release):
-        section = self._findDriveSection(vendor, model, release)
-
-        try:
-            return self._parser.get(section, 'defeats_cache') == 'True'
-        except ConfigParser.NoOptionError:
-            raise KeyError("Could not find defeats_cache for %s/%s/%s" % (
-                vendor, model, release))
+        return self._getDriveOption(vendor, model, release, 'defeats_cache') == 'True'
 
     def _findDriveSection(self, vendor, model, release):
         for name in self._parser.sections():
@@ -162,3 +142,23 @@ class Config:
         self.write()
 
         return self._findDriveSection(vendor, model, release)
+
+    def _getDriveOption(self, vendor, model, release, key):
+        """
+        Get an option for the given drive.
+        """
+        section = self._findDriveSection(vendor, model, release)
+        try:
+            return self._parser.get(section, key)
+        except ConfigParser.NoOptionError:
+            raise KeyError("Could not find %s for %s/%s/%s" % (key, vendor, model, release))
+
+    def _setDriveOption(self, vendor, model, release, key, value):
+        """
+        Set an option for the given drive.
+
+        Strips the given strings of leading and trailing whitespace.
+        """
+        section = self._findOrCreateDriveSection(vendor, model, release)
+        self._parser.set(section, key, str(value))
+        self.write()

--- a/whipper/common/config.py
+++ b/whipper/common/config.py
@@ -105,6 +105,12 @@ class Config:
     def getDefeatsCache(self, vendor, model, release):
         return self._getDriveOption(vendor, model, release, 'defeats_cache') == 'True'
 
+    def getForceFastToc(self, vendor, model, release):
+        try:
+            return self._getDriveOption(vendor, model, release, 'force_fast_toc') == 'True'
+        except KeyError:
+            return False
+
     def _findDriveSection(self, vendor, model, release):
         for name in self._parser.sections():
             if not name.startswith('drive:'):

--- a/whipper/test/test_result_logger.py
+++ b/whipper/test/test_result_logger.py
@@ -141,7 +141,7 @@ class LoggerTestCase(unittest.TestCase):
             actualLines[0],
             re.compile((
                 r'Log created by: whipper '
-                r'[\d]+\.[\d]+.[\d]+\.dev[\w\.\+]+ \(internal logger\)'
+                r'[\d]+\.[\d]+\.[\d]+\.dev[\w\.\+]+ \(internal logger\)'
             ))
         )
         self.assertRegexpMatches(


### PR DESCRIPTION
This makes whipper compatible with my best drives, `MATSHITA DVD-RAM UJ-842 RB01` and
`MATSHITA DVD-R UJ-857E ZA0E`. I don't think there's a good way to autodetect the need for this option, since sometimes the drives wouldn't fail (the longer the disc's playing time, the more likely problems are to occur).

For further details on this topic see the discussion at PR https://github.com/JoeLametta/whipper/pull/264.