### PR TITLE
Store ToC file generated by cdrdao

### DIFF
--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -134,11 +134,18 @@ class _CD(BaseCommand):
                             "--cdr not passed")
             return -1
 
+        out_bpath = self.options.output_directory.decode('utf-8')
+        # Needed to preserve cdrdao's tocfile
+        out_fpath = self.program.getPath(out_bpath,
+                                         self.options.disc_template,
+                                         self.mbdiscid,
+                                         self.program.metadata)
         # now, read the complete index table, which is slower
         self.itable = self.program.getTable(self.runner,
                                             self.ittoc.getCDDBDiscId(),
                                             self.ittoc.getMusicBrainzDiscId(),
-                                            self.device, self.options.offset)
+                                            self.device, self.options.offset,
+                                            out_bpath, out_fpath)
 
         assert self.itable.getCDDBDiscId() == self.ittoc.getCDDBDiscId(), \
             "full table's id %s differs from toc id %s" % (
@@ -326,9 +333,6 @@ Log files will log the path to tracks relative to this directory.
                        dirname.encode('utf-8'))
                 logger.critical(msg)
                 raise RuntimeError(msg)
-            else:
-                sys.stdout.write("output directory %s already exists\n" %
-                                 dirname.encode('utf-8'))
         else:
             print("creating output directory %s" % dirname.encode('utf-8'))
             os.makedirs(dirname)

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -104,7 +104,8 @@ class Program:
         assert toc.hasTOC()
         return toc
 
-    def getTable(self, runner, cddbdiscid, mbdiscid, device, offset):
+    def getTable(self, runner, cddbdiscid, mbdiscid, device, offset,
+                 out_bpath, out_fpath):
         """
         Retrieve the Table either from the cache or the drive.
 
@@ -126,7 +127,7 @@ class Program:
             logger.debug('getTable: cddbdiscid %s, mbdiscid %s not '
                          'in cache for offset %s, reading table' % (
                              cddbdiscid, mbdiscid, offset))
-            t = cdrdao.ReadTableTask(device)
+            t = cdrdao.ReadTableTask(device, out_bpath, out_fpath)
             itable = t.table
             tdict[offset] = itable
             ptable.persist(tdict)

--- a/whipper/program/cdrdao.py
+++ b/whipper/program/cdrdao.py
@@ -1,9 +1,10 @@
 import os
 import re
+import shutil
 import tempfile
 from subprocess import Popen, PIPE
 
-from whipper.common.common import EjectError
+from whipper.common.common import EjectError, truncate_filename
 from whipper.image.toc import TocFile
 
 import logging
@@ -12,7 +13,7 @@ logger = logging.getLogger(__name__)
 CDRDAO = 'cdrdao'
 
 
-def read_toc(device, fast_toc=False):
+def read_toc(device, fast_toc=False, toc_bpath=None, toc_fpath=None):
     """
     Return cdrdao-generated table of contents for 'device'.
     """
@@ -43,6 +44,14 @@ def read_toc(device, fast_toc=False):
 
     toc = TocFile(tocfile)
     toc.parse()
+    if toc_fpath is not None:
+        t_comp = os.path.abspath(toc_fpath).split(os.sep)
+        t_dirn = os.sep.join(t_comp[:-1])
+        # If the output path doesn't exist, make it recursively
+        if not os.path.isdir(t_dirn):
+            os.makedirs(t_dirn)
+        t_dst = truncate_filename(os.path.join(t_dirn, t_comp[-1] + '.toc'))
+        shutil.copy(tocfile, os.path.join(t_dirn, t_dst))
     os.unlink(tocfile)
     return toc
 
@@ -86,11 +95,11 @@ def ReadTOCTask(device):
     return read_toc(device, fast_toc=True)
 
 
-def ReadTableTask(device):
+def ReadTableTask(device, toc_bpath=None, toc_fpath=None):
     """
     stopgap morituri-insanity compatibility layer
     """
-    return read_toc(device)
+    return read_toc(device, toc_bpath=toc_bpath, toc_fpath=toc_fpath)
 
 
 def getCDRDAOVersion():


### PR DESCRIPTION
Fixes #214.

This FR isn't implemented as an option because I think always having the original toc file could be useful for debugging purposes, burning a copy of the source CD and it's a tiny file anyway...