### PR TITLE
Revert "task: implement logging"

### DIFF
--- a/whipper/extern/task/task.py
+++ b/whipper/extern/task/task.py
@@ -18,15 +18,12 @@
 # You should have received a copy of the GNU General Public License
 # along with whipper.  If not, see <http://www.gnu.org/licenses/>.
 
-import logging
 import sys
 
 try:
     from gi.repository import GLib as gobject
 except ImportError:
     import gobject
-
-logger = logging.getLogger(__name__)
 
 
 class TaskException(Exception):
@@ -76,14 +73,21 @@ class LogStub(object):
     I am a stub for a log interface.
     """
 
+    # log stubs
     def log(self, message, *args):
-        logger.info(message, *args)
+        pass
 
     def debug(self, message, *args):
-        logger.debug(message, *args)
+        pass
+
+    def info(self, message, *args):
+        pass
 
     def warning(self, message, *args):
-        logger.warning(message, *args)
+        pass
+
+    def error(self, message, *args):
+        pass
 
 
 class Task(LogStub):


### PR DESCRIPTION
This reverts commit a5e3b0d3254967cb11689bd140194d406cf9dca5.

These were silenced previously due to inflating log files into the (sometimes hundreds of!) megabytes when running in debug mode while failing to provide any diagnostic value.