### PR TITLE
Limit length of filenames

### DIFF
--- a/whipper/common/common.py
+++ b/whipper/common/common.py
@@ -152,6 +152,16 @@ class MissingFrames(Exception):
     """
     pass
 
+def truncate_filename(path):
+    """
+    Truncate filename to the max. len. allowed by the path's filesystem
+    Should handle unicode correctly too
+    """
+    p, f = os.path.split(os.path.normpath(path))
+    f, e = os.path.splitext(f)
+    fn_lim = os.pathconf(p, 'PC_NAME_MAX')
+    length = fn_lim - len(e)
+    return os.path.join(p, f[:length] + e)
 
 def shrinkPath(path):
     """

--- a/whipper/common/common.py
+++ b/whipper/common/common.py
@@ -152,6 +152,7 @@ class MissingFrames(Exception):
     """
     pass
 
+
 def truncate_filename(path):
     """
     Truncate filename to the max. len. allowed by the path's filesystem
@@ -162,6 +163,7 @@ def truncate_filename(path):
     fn_lim = os.pathconf(p, 'PC_NAME_MAX')
     length = fn_lim - len(e)
     return os.path.join(p, f[:length] + e)
+
 
 def shrinkPath(path):
     """

--- a/whipper/common/common.py
+++ b/whipper/common/common.py
@@ -23,6 +23,7 @@ import os
 import os.path
 import math
 import subprocess
+import unicodedata
 
 from whipper.extern import asyncsub
 
@@ -156,13 +157,15 @@ class MissingFrames(Exception):
 def truncate_filename(path):
     """
     Truncate filename to the max. len. allowed by the path's filesystem
-    Should handle unicode correctly too
+    Hopefully it handles Unicode strings correctly
     """
     p, f = os.path.split(os.path.normpath(path))
     f, e = os.path.splitext(f)
-    fn_lim = os.pathconf(p, 'PC_NAME_MAX')
-    length = fn_lim - len(e)
-    return os.path.join(p, f[:length] + e)
+    fn_lim = os.pathconf(p, 'PC_NAME_MAX')  # max filenmae length in bytes
+    max = fn_lim - len(e.encode('utf-8'))
+    f = unicodedata.normalize('NFC', f)
+    f_trunc = unicode(f.encode('utf-8')[:max], 'utf-8', errors='ignore')
+    return os.path.join(p, f_trunc + e)
 
 
 def shrinkPath(path):

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -574,7 +574,7 @@ class Program:
         return accurip.verify_result(self.result, responses, checksums)
 
     def write_m3u(self, discname):
-        m3uPath = u'%s.m3u' % discname
+        m3uPath = common.truncate_filename(discname + '.m3u')
         with open(m3uPath, 'w') as f:
             f.write(u'#EXTM3U\n'.encode('utf-8'))
             for track in self.result.tracks:
@@ -596,7 +596,7 @@ class Program:
 
     def writeCue(self, discName):
         assert self.result.table.canCue()
-        cuePath = '%s.cue' % discName
+        cuePath = common.truncate_filename(discName + '.cue')
         logger.debug('write .cue file to %s', cuePath)
         handle = open(cuePath, 'w')
         # FIXME: do we always want utf-8 ?
@@ -608,7 +608,7 @@ class Program:
         return cuePath
 
     def writeLog(self, discName, logger):
-        logPath = '%s.log' % discName
+        logPath = common.truncate_filename(discName + '.log')
         handle = open(logPath, 'w')
         log = logger.log(self.result)
         handle.write(log.encode('utf-8'))

--- a/whipper/program/cdparanoia.py
+++ b/whipper/program/cdparanoia.py
@@ -481,8 +481,8 @@ class ReadVerifyTrackTask(task.MultiSeparateTask):
         except IOError as e:
             if errno.ENAMETOOLONG != e.errno:
                 raise
-            path = common.shrinkPath(path)
-            tmpoutpath = path + u'.part'
+            path = common.truncate_filename(common.shrinkPath(path))
+            tmpoutpath = common.truncate_filename(path + u'.part')
             open(tmpoutpath, 'wb').close()
         self._tmppath = tmpoutpath
         self.path = path


### PR DESCRIPTION
If whipper generated filenames are longer than the maximum value supported by the filesystem, I/O operations are going to fail.
With this commit filenames which may be too long are truncated to the maximum supported length.

Fixes #197.