### PR TITLE
Preserve ToC file generated by cdrdao

### DIFF
--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -135,11 +135,21 @@ class _CD(BaseCommand):
                             "--cdr not passed")
             return -1
 
+        # Change working directory before cdrdao's task
+        if self.options.working_directory is not None:
+            os.chdir(os.path.expanduser(self.options.working_directory))
+        out_bpath = self.options.output_directory.decode('utf-8')
+        # Needed to preserve cdrdao's tocfile
+        out_fpath = self.program.getPath(out_bpath,
+                                         self.options.disc_template,
+                                         self.mbdiscid,
+                                         self.program.metadata)
         # now, read the complete index table, which is slower
         self.itable = self.program.getTable(self.runner,
                                             self.ittoc.getCDDBDiscId(),
                                             self.ittoc.getMusicBrainzDiscId(),
-                                            self.device, self.options.offset)
+                                            self.device, self.options.offset,
+                                            out_fpath)
 
         assert self.itable.getCDDBDiscId() == self.ittoc.getCDDBDiscId(), \
             "full table's id %s differs from toc id %s" % (
@@ -329,9 +339,6 @@ Log files will log the path to tracks relative to this directory.
                        dirname.encode('utf-8'))
                 logger.critical(msg)
                 raise RuntimeError(msg)
-            else:
-                sys.stdout.write("output directory %s already exists\n" %
-                                 dirname.encode('utf-8'))
         else:
             print("creating output directory %s" % dirname.encode('utf-8'))
             os.makedirs(dirname)

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -104,7 +104,8 @@ class Program:
         assert toc.hasTOC()
         return toc
 
-    def getTable(self, runner, cddbdiscid, mbdiscid, device, offset):
+    def getTable(self, runner, cddbdiscid, mbdiscid, device, offset,
+                 out_path):
         """
         Retrieve the Table either from the cache or the drive.
 
@@ -126,7 +127,7 @@ class Program:
             logger.debug('getTable: cddbdiscid %s, mbdiscid %s not '
                          'in cache for offset %s, reading table' % (
                              cddbdiscid, mbdiscid, offset))
-            t = cdrdao.ReadTableTask(device)
+            t = cdrdao.ReadTableTask(device, out_path)
             itable = t.table
             tdict[offset] = itable
             ptable.persist(tdict)


### PR DESCRIPTION
Whipper uses cdrdao during its ripping process. With this commit it will now store cdrdao's generated tocfile in the ripping path.
Preserving the tocfile allows users to easily burn ripped discs having a non-compliant cue sheet.

Fixes #214.

Previous comments are available in https://github.com/whipper-team/whipper/pull/277.