### PR TITLE
Raise exception if template has invalid variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ read_offset = 6			; drive read offset in positive/negative frames (no leading +)
 unknown = True
 output_directory = ~/My Music
 track_template = new/%%A/%%y - %%d/%%t - %%n	; note: the format char '%' must be represented '%%'
-disc_template = %(track_template)s
+disc_template =  new/%%A/%%y - %%d/%%A - %%d
 # ...
 ```
 

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -196,6 +196,10 @@ class Program:
         """
         assert isinstance(outdir, unicode), "%r is not unicode" % outdir
         assert isinstance(template, unicode), "%r is not unicode" % template
+        matches = re.findall(r"%[^A,S,d,y,r,R,x,X]", template)
+        if '%' in template and matches:
+            raise ValueError('disc template string contains invalid '
+                             'variable(s): {}.'.format(', '.join(matches)))
         v = {}
         v['A'] = 'Unknown Artist'
         v['d'] = mbdiscid  # fallback for title


### PR DESCRIPTION
If the template string contains variables which aren't valid for whipper, raise `ValueError` exception listing all the included unrecognized variables.
I've also corrected the example template configuration lines in the README.

Fixes #279.