### PR TITLE
Fix template validation error

### DIFF
--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -28,6 +28,7 @@ from whipper.command.basecommand import BaseCommand
 from whipper.common import (
     accurip, config, drive, program, task
 )
+from whipper.common.common import validate_template
 from whipper.program import cdrdao, cdparanoia, utils
 from whipper.result import result
 
@@ -285,7 +286,9 @@ Log files will log the path to tracks relative to this directory.
 
         self.options.track_template = self.options.track_template.decode(
             'utf-8')
+        validate_template(self.options.track_template, 'track')
         self.options.disc_template = self.options.disc_template.decode('utf-8')
+        validate_template(self.options.disc_template, 'disc')
 
         if self.options.offset is None:
             raise ValueError("Drive offset is unconfigured.\n"

--- a/whipper/common/common.py
+++ b/whipper/common/common.py
@@ -22,6 +22,7 @@
 import os
 import os.path
 import math
+import re
 import subprocess
 import unicodedata
 
@@ -278,6 +279,19 @@ def getRelativePath(targetPath, collectionPath):
             'getRelativePath: target and collection in different dir, %r' % rel
         )
         return os.path.join(rel, os.path.basename(targetPath))
+
+
+def validate_template(template, kind):
+    """
+    Raise exception if disc/track template includes invalid variables
+    """
+    if kind == 'disc':
+        matches = re.findall(r'%[^A,R,S,X,d,r,x,y]', template)
+    elif kind == 'track':
+        matches = re.findall(r'%[^A,R,S,X,a,d,n,r,s,t,x,y]', template)
+    if '%' in template and matches:
+        raise ValueError(kind + ' template string contains invalid '
+                         'variable(s): {}'.format(', '.join(matches)))
 
 
 class VersionGetter(object):

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -196,10 +196,6 @@ class Program:
         """
         assert isinstance(outdir, unicode), "%r is not unicode" % outdir
         assert isinstance(template, unicode), "%r is not unicode" % template
-        matches = re.findall(r"%[^A,S,d,y,r,R,x,X]", template)
-        if '%' in template and matches:
-            raise ValueError('disc template string contains invalid '
-                             'variable(s): {}.'.format(', '.join(matches)))
         v = {}
         v['A'] = 'Unknown Artist'
         v['d'] = mbdiscid  # fallback for title


### PR DESCRIPTION
Commit 9c72ebccd31f32c78bdc4741971233f8792db7b7 introduced a bug: all template strings are validated against the disc template RegEx (which, for example, is wrong if we're testing the track template).