### PR TITLE
Prevent exception in offset find

### DIFF
--- a/whipper/command/offset.py
+++ b/whipper/command/offset.py
@@ -93,7 +93,8 @@ CD in the AccurateRip database."""
         try:
             responses = accurip.get_db_entry(table.accuraterip_path())
         except accurip.EntryNotFound:
-            print('Accuraterip entry not found')
+            logger.warning("AccurateRip entry not found: drive offset "
+                           "can't be determined, try again with another disc")
 
         if responses:
             logger.debug('%d AccurateRip responses found.' % len(responses))

--- a/whipper/command/offset.py
+++ b/whipper/command/offset.py
@@ -95,6 +95,7 @@ CD in the AccurateRip database."""
         except accurip.EntryNotFound:
             logger.warning("AccurateRip entry not found: drive offset "
                            "can't be determined, try again with another disc")
+            return
 
         if responses:
             logger.debug('%d AccurateRip responses found.' % len(responses))


### PR DESCRIPTION
Whipper offset find needs a (remote) matching AccurateRip entry to perform its task and confirm the drive offset: if none is found, return early to prevent exception.
I've also converted a print statement into a logger warning with a better textual description of the issue.

Fixes #208.