### PR TITLE
Avoid zero padding in logger track numbers

### DIFF
--- a/whipper/result/logger.py
+++ b/whipper/result/logger.py
@@ -166,7 +166,7 @@ class WhipperLogger(result.Logger):
         lines = []
 
         # Track number
-        lines.append("  %02d:" % trackResult.number)
+        lines.append("  %d:" % trackResult.number)
 
         # Filename (including path) of ripped track
         lines.append("    Filename: %s" % trackResult.filename)


### PR DESCRIPTION
Fixes the second dictionary (Tracks) from #340 

Commit 4a53ecba2c25dc580df7b05d9ec0dc55c7b4db15 fixed this issue within the TOC dictionary, but the issue still remained for the Tracks dictionary.