### PR TITLE
WIP: Refactor cdrdao toc/table functions into Task and provide progress output

### DIFF
--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -94,7 +94,6 @@ class _CD(BaseCommand):
         utils.unmount_device(self.device)
 
         # first, read the normal TOC, which is fast
-        logger.info("reading TOC...")
         self.ittoc = self.program.getFastToc(self.runner, self.device)
 
         # already show us some info based on this

--- a/whipper/program/cdrdao.py
+++ b/whipper/program/cdrdao.py
@@ -24,9 +24,37 @@ _LAST_TRACK_RE = re.compile(r"^(?P<track>[0-9]*)")
 _LEADOUT_RE = re.compile(
     r"^Leadout AUDIO\s*[0-9]\s*[0-9]*:[0-9]*:[0-9]*\([0-9]*\)")
 
+
 class ProgressParser:
+    tracks = 0
+    currentTrack = 0
+    oldline = ''  # for leadout/final track number detection
+
     def parse(self, line):
-       pass 
+        cdrdao_m = _BEGIN_CDRDAO_RE.match(line)
+
+        if cdrdao_m:
+            logger.debug("RE: Begin cdrdao toc-read")
+
+        leadout_m = _LEADOUT_RE.match(line)
+
+        if leadout_m:
+            logger.debug("RE: Reached leadout")
+            last_track_m = _LAST_TRACK_RE.match(self.oldline)
+            if last_track_m:
+                self.tracks = last_track_m.group('track')
+
+        track_s = _TRACK_RE.search(line)
+        if track_s:
+            logger.debug("RE: Began reading track: %d" 
+                    % int(track_s.group('track')))
+            self.currentTrack = int(track_s.group('track'))
+
+        crc_s = _CRC_RE.search(line)
+        if crc_s:
+            sys.stdout.write("Track %d finished, found %d Q sub-channels with CRC errors\n" % (self.currentTrack, int(crc_s.group('channels'))) )
+
+        self.oldline = line
         
 
 class ReadTOCTask(task.Task):
@@ -52,6 +80,9 @@ class ReadTOCTask(task.Task):
         self.fast_toc = fast_toc
         self.toc_path = toc_path
         self._buffer = ""  # accumulate characters
+        self._parser = ProgressParser()
+        
+        self.fd, self.tocfile = tempfile.mkstemp(suffix=u'.cdrdao.read-toc.whipper.task')
 
     def start(self, runner):
         task.Task.start(self, runner)
@@ -67,39 +98,9 @@ class ReadTOCTask(task.Task):
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE,
                                      close_fds=True)
-        def _read(self, runner):
-            ret = self._popen.recv_err()
-            if not ret:
-                if self._popen.poll() is not None:
-                    self._done()
-                    return
-                self.schedule(0.01, self._read, runner)
-                return
-            self._buffer += ret
-            
-            # parse buffer into lines if possible, and parse them
-            if "\n" in self._buffer:
-                lines = self._buffer.split('\n')
-                if lines[-1] != "\n":
-                    # last line didn't end yet
-                    self._buffer = lines[-1]
-                    del lines[-1]
-                else:
-                    self._buffer = ""
-
-                for line in lines:
-                    sys.stdout.write("%s\n" % line)
-
-                progress = float(num) / float(den)
-                if progress < 1.0:
-                    self.setProgress(progress)
-            
-            # 0 does not give us output before we complete, 1.0 gives us output
-            # too late
-            
-            self._start_time = time.time()
-            self.schedule(1.0, self._read, runner)
         
+        self.schedule(0.01, self._read, runner)
+
     def _read(self, runner):
         ret = self._popen.recv_err()
         if not ret:
@@ -112,7 +113,6 @@ class ReadTOCTask(task.Task):
 
         # parse buffer into lines if possible, and parse them
         if "\n" in self._buffer:
-
             lines = self._buffer.split('\n')
             if lines[-1] != "\n":
                 # last line didn't end yet
@@ -121,14 +121,17 @@ class ReadTOCTask(task.Task):
             else:
                 self._buffer = ""
             for line in lines:
-                sys.stdout.write("%s\n" % line)
+                self._parser.parse(line)
+                if (self._parser.currentTrack is not 0 and self._parser.tracks is not 0):
+                    progress = float('%d' % self._parser.currentTrack) / float(self._parser.tracks)
+                    if progress < 1.0:
+                        self.setProgress(progress)
 
         # 0 does not give us output before we complete, 1.0 gives us output
         # too late
         self.schedule(0.01, self._read, runner)
 
     def _poll(self, runner):
-
         if self._popen.poll() is None:
             self.schedule(1.0, self._poll, runner)
             return

--- a/whipper/program/cdrdao.py
+++ b/whipper/program/cdrdao.py
@@ -1,17 +1,99 @@
+import sys
 import os
 import re
 import shutil
 import tempfile
 from subprocess import Popen, PIPE
 
-from whipper.common.common import EjectError, truncate_filename
+from whipper.common.common import truncate_filename
 from whipper.image.toc import TocFile
+from whipper.extern.task import task
+from whipper.extern import asyncsub
 
 import logging
 logger = logging.getLogger(__name__)
 
 CDRDAO = 'cdrdao'
 
+class ReadTOCTask(task.Task):
+    """
+    Task that reads the TOC of the disc using cdrdao
+    """
+    description = "Reading TOC"
+    toc = None
+    
+    def __init__(self, device, fast_toc=False, toc_path=None):
+        """
+        Read the TOC for 'device'.
+        @device: path of device
+        @type device: str
+        @param fast_toc: use cdrdao fast-toc mode
+        @type fast_toc: bool
+        @param toc_path: Where to save the generated table of contents
+        @type str
+        """
+        
+        self.device = device
+        self.fast_toc = fast_toc
+        self.toc_path = toc_path
+        
+    def start(self, runner):
+        task.Task.start(self, runner)
+
+        cmd = [CDRDAO, 'read-toc'] + (['--fast-toc'] if fast_toc else []) + [
+            '--device', device, tocfile]
+        
+        self._popen = asyncsub.Popen(cmd,
+                                     bufsize=1024,
+                                     stdin=subprocess.PIPE,
+                                     stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE,
+                                     close_fds=True)
+        def _read(self, runner):
+            ret = self._popen.recv_err()
+            if not ret:
+                if self._popen.poll() is not None:
+                    self._done()
+                    return
+                self.schedule(0.01, self._read, runner)
+                return
+            self._buffer += ret
+            
+            # parse buffer into lines if possible, and parse them
+            if "\n" in self._buffer:
+                 lines = self._buffer.split('\n')
+                if lines[-1] != "\n":
+                    # last line didn't end yet
+                    self._buffer = lines[-1]
+                    del lines[-1]
+                else:
+                    self._buffer = ""
+
+                for line in lines:
+                    sys.stdout.write("%s\n" % line)
+
+                progress = float(num) / float(den)
+                if progress < 1.0:
+                    self.setProgress(progress)
+            
+            # 0 does not give us output before we complete, 1.0 gives us output
+            # too late
+            self.schedule(0.01, self._read, runner)
+
+
+    def _poll(self, runner):
+        if self._popen.poll() is None:
+            self.schedule(1.0, self._poll, runner)
+            return
+
+        self._done()
+
+
+    def _done(self):
+        self.setProgress(1.0)
+
+        self.stop()
+        return
 
 def read_toc(device, fast_toc=False, toc_path=None):
     """


### PR DESCRIPTION
This PR fixes issue #299 and also refactors the cdrdao read toc function into a Task as a prerequisite for this. I've rebased my changes against the upstream/develop branch and ran a [test rip](https://gist.github.com/jtl999/037a40da978cdc3a7c7ff7646d3835a9) just now.

A question. Now that at present we aren't using fast_toc, do we really need to read the TOC and table separately, when it appears they contain the same data, except for the offset in the table. Would shave some time off ripping if it's possible to only need to do it once, but I feel such a change would be out of scope of this PR.

Fixes #299.