### PR TITLE
Clarify format option for disc template

### DIFF
--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -182,7 +182,7 @@ class Program:
         template, filling in the variables and adding the file
         extension. Variables for both disc and track template are:
           - %A: album artist
-          - %S: album sort name
+          - %S: album artist sort name
           - %d: disc title
           - %y: release year
           - %r: release type, lowercase


### PR DESCRIPTION
The previous text implied to me that this was the sort name for the Album/Disc title.  Not the artist sort name.