### PR TITLE
Clean up MusicBrainz nomenclature

### DIFF
--- a/TODO
+++ b/TODO
@@ -56,7 +56,7 @@ HARD
 
 - write xbmc/plex plugin
 
-SPECIFIC ALBUMS ISSUES
+SPECIFIC RELEASES ISSUES
 
 - on ana, Goldfrapp tells me I have offset 0!
 
@@ -67,7 +67,7 @@ SPECIFIC ALBUMS ISSUES
 
 NO DECISION YET
 
-- possibly figure out how to name albums with credited artist; look at gorky and spiritualized electric mainline
+- possibly figure out how to name releases with credited artist; look at gorky and spiritualized electric mainline
 
 - check if cdda2wav or icedax analyze pregaps correctly
 

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -51,8 +51,8 @@ and adding the file extension.  Variables exclusive to the track template are:
 Disc files (.cue, .log, .m3u) are named according to the disc template,
 filling in the variables and adding the file extension. Variables for both
 disc and track template are:
- - %A: album artist
- - %S: album sort name
+ - %A: release artist
+ - %S: release sort name
  - %d: disc title
  - %y: release year
  - %r: release type, lowercase

--- a/whipper/common/mbngs.py
+++ b/whipper/common/mbngs.py
@@ -57,7 +57,7 @@ class TrackMetadata(object):
 class DiscMetadata(object):
     """
     @param artist:       artist(s) name
-    @param sortName:     album artist sort name
+    @param sortName:     release artist sort name
     @param release:      earliest release date, in YYYY-MM-DD
     @type  release:      unicode
     @param title:        title of the disc (with disambiguation)
@@ -176,10 +176,10 @@ def _getMetadata(releaseShort, release, discid, country=None):
     if len(discCredit) > 1:
         logger.debug('artist-credit more than 1: %r', discCredit)
 
-    albumArtistName = discCredit.getName()
+    releaseArtistName = discCredit.getName()
 
     # getUniqueName gets disambiguating names like Muse (UK rock band)
-    discMD.artist = albumArtistName
+    discMD.artist = releaseArtistName
     discMD.sortName = discCredit.getSortName()
     if 'date' not in release:
         logger.warning("release with ID '%s' (%s - %s) does not have a date",

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -393,7 +393,7 @@ class Program:
                     track = self.metadata.tracks[number - 1]
                     trackArtist = track.artist
                     title = track.title
-                    mbidTrack = track.mbid
+                    mbidRecording = track.mbid
                     mbidTrackArtist = track.mbidArtist
                 except IndexError as e:
                     logger.error('no track %d found, %r', number, e)
@@ -420,7 +420,7 @@ class Program:
                 tags['DATE'] = self.metadata.release
 
             if number > 0:
-                tags['MUSICBRAINZ_TRACKID'] = mbidTrack
+                tags['MUSICBRAINZ_TRACKID'] = mbidRecording
                 tags['MUSICBRAINZ_ARTISTID'] = mbidTrackArtist
                 tags['MUSICBRAINZ_ALBUMID'] = mbidRelease
                 tags['MUSICBRAINZ_ALBUMARTISTID'] = mbidReleaseArtist

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -169,8 +169,8 @@ class Program:
         Disc files (.cue, .log, .m3u) are named according to the disc
         template, filling in the variables and adding the file
         extension. Variables for both disc and track template are:
-          - %A: album artist
-          - %S: album artist sort name
+          - %A: release artist
+          - %S: release artist sort name
           - %d: disc title
           - %y: release year
           - %r: release type, lowercase
@@ -377,16 +377,16 @@ class Program:
         @rtype: dict
         """
         trackArtist = u'Unknown Artist'
-        albumArtist = u'Unknown Artist'
+        releaseArtist = u'Unknown Artist'
         disc = u'Unknown Disc'
         title = u'Unknown Track'
 
         if self.metadata:
             trackArtist = self.metadata.artist
-            albumArtist = self.metadata.artist
+            releaseArtist = self.metadata.artist
             disc = self.metadata.title
-            mbidAlbum = self.metadata.mbid
-            mbidTrackAlbum = self.metadata.mbidArtist
+            mbidRelease = self.metadata.mbid
+            mbidReleaseArtist = self.metadata.mbidArtist
 
             if number > 0:
                 try:
@@ -408,7 +408,7 @@ class Program:
             tags['MUSICBRAINZ_DISCID'] = mbdiscid
 
         if self.metadata and not self.metadata.various:
-            tags['ALBUMARTIST'] = albumArtist
+            tags['ALBUMARTIST'] = releaseArtist
         tags['ARTIST'] = trackArtist
         tags['TITLE'] = title
         tags['ALBUM'] = disc
@@ -422,8 +422,8 @@ class Program:
             if number > 0:
                 tags['MUSICBRAINZ_TRACKID'] = mbidTrack
                 tags['MUSICBRAINZ_ARTISTID'] = mbidTrackArtist
-                tags['MUSICBRAINZ_ALBUMID'] = mbidAlbum
-                tags['MUSICBRAINZ_ALBUMARTISTID'] = mbidTrackAlbum
+                tags['MUSICBRAINZ_ALBUMID'] = mbidRelease
+                tags['MUSICBRAINZ_ALBUMARTISTID'] = mbidReleaseArtist
 
         # TODO/FIXME: ISRC tag
 

--- a/whipper/result/logger.py
+++ b/whipper/result/logger.py
@@ -65,7 +65,8 @@ class WhipperLogger(result.Logger):
 
         # CD metadata
         lines.append("CD metadata:")
-        lines.append("  Album: %s - %s" % (ripResult.artist, ripResult.title))
+        lines.append("  Release: %s - %s" %
+                     (ripResult.artist, ripResult.title))
         lines.append("  CDDB Disc ID: %s" % ripResult. table.getCDDBDiscId())
         lines.append("  MusicBrainz Disc ID: %s" %
                      ripResult. table.getMusicBrainzDiscId())


### PR DESCRIPTION
A series of commits for cleaning up various internal (e.g., variable names) and external uses of terms fetched from MusicBrainz that do not match up with what MusicBrainz calls the same concepts. This is mostly to make the code a bit clearer for someone familiar with MusicBrainz, but also to clear up some inconsistencies—e.g., you would have "%A: album artist" but "%y: release year" before, even though they're both referring to an MB Release "object".

See explanations for changes in individual commits.