### PR TITLE
Handle artist MBIDs as multivalue tags

### DIFF
--- a/whipper/common/mbngs.py
+++ b/whipper/common/mbngs.py
@@ -143,8 +143,9 @@ class _Credit(list):
                                            i.get('artist').get('name', None)))
 
     def getIds(self):
+        # split()'s the joined string so we get a proper list of MBIDs
         return self.joiner(lambda i: i.get('artist').get('id', None),
-                           joinString=";")
+                           joinString=";").split(';')
 
 
 def _getWorks(recording):

--- a/whipper/test/test_common_mbngs.py
+++ b/whipper/test/test_common_mbngs.py
@@ -40,16 +40,17 @@ class MetadataTestCase(unittest.TestCase):
         self.assertEqual(metadata.artist, u'Various Artists')
         self.assertEqual(metadata.release, u'2001-10-15')
         self.assertEqual(metadata.mbidArtist,
-                         u'89ad4ac3-39f7-470e-963a-56509c546377')
+                         [u'89ad4ac3-39f7-470e-963a-56509c546377'])
 
         self.assertEqual(len(metadata.tracks), 18)
 
         track16 = metadata.tracks[15]
 
         self.assertEqual(track16.artist, 'Tom Jones & Stereophonics')
-        self.assertEqual(track16.mbidArtist,
-                         u'57c6f649-6cde-48a7-8114-2a200247601a'
-                         ';0bfba3d3-6a04-4779-bb0a-df07df5b0558')
+        self.assertEqual(track16.mbidArtist, [
+            u'57c6f649-6cde-48a7-8114-2a200247601a',
+            u'0bfba3d3-6a04-4779-bb0a-df07df5b0558',
+        ])
         self.assertEqual(track16.sortName,
                          u'Jones, Tom & Stereophonics')
 
@@ -68,9 +69,10 @@ class MetadataTestCase(unittest.TestCase):
         self.assertEqual(metadata.sortName,
                          u'Campbell, Isobel & Lanegan, Mark')
         self.assertEqual(metadata.release, u'2006-01-30')
-        self.assertEqual(metadata.mbidArtist,
-                         u'd51f3a15-12a2-41a0-acfa-33b5eae71164;'
-                         'a9126556-f555-4920-9617-6e013f8228a7')
+        self.assertEqual(metadata.mbidArtist, [
+            u'd51f3a15-12a2-41a0-acfa-33b5eae71164',
+            u'a9126556-f555-4920-9617-6e013f8228a7',
+        ])
 
         self.assertEqual(len(metadata.tracks), 12)
 
@@ -80,9 +82,10 @@ class MetadataTestCase(unittest.TestCase):
         self.assertEqual(track12.sortName,
                          u'Campbell, Isobel'
                          ' & Lanegan, Mark')
-        self.assertEqual(track12.mbidArtist,
-                         u'd51f3a15-12a2-41a0-acfa-33b5eae71164;'
-                         'a9126556-f555-4920-9617-6e013f8228a7')
+        self.assertEqual(track12.mbidArtist, [
+            u'd51f3a15-12a2-41a0-acfa-33b5eae71164',
+            u'a9126556-f555-4920-9617-6e013f8228a7',
+        ])
 
     def testMalaInCuba(self):
         # single artist disc, but with multiple artists tracks
@@ -100,7 +103,7 @@ class MetadataTestCase(unittest.TestCase):
         self.assertEqual(metadata.sortName, u'Mala')
         self.assertEqual(metadata.release, u'2012-09-17')
         self.assertEqual(metadata.mbidArtist,
-                         u'09f221eb-c97e-4da5-ac22-d7ab7c555bbb')
+                         [u'09f221eb-c97e-4da5-ac22-d7ab7c555bbb'])
 
         self.assertEqual(len(metadata.tracks), 14)
 
@@ -109,10 +112,11 @@ class MetadataTestCase(unittest.TestCase):
         self.assertEqual(track6.artist, u'Mala feat. Dreiser & Sexto Sentido')
         self.assertEqual(track6.sortName,
                          u'Mala feat. Dreiser & Sexto Sentido')
-        self.assertEqual(track6.mbidArtist,
-                         u'09f221eb-c97e-4da5-ac22-d7ab7c555bbb'
-                         ';ec07a209-55ff-4084-bc41-9d4d1764e075'
-                         ';f626b92e-07b1-4a19-ad13-c09d690db66c')
+        self.assertEqual(track6.mbidArtist, [
+            u'09f221eb-c97e-4da5-ac22-d7ab7c555bbb',
+            u'ec07a209-55ff-4084-bc41-9d4d1764e075',
+            u'f626b92e-07b1-4a19-ad13-c09d690db66c',
+        ])
 
     def testUnknownArtist(self):
         """
@@ -134,7 +138,7 @@ class MetadataTestCase(unittest.TestCase):
         self.assertEqual(metadata.artist, u'CunninLynguists')
         self.assertEqual(metadata.release, u'2003')
         self.assertEqual(metadata.mbidArtist,
-                         u'69c4cc43-8163-41c5-ac81-30946d27bb69')
+                         [u'69c4cc43-8163-41c5-ac81-30946d27bb69'])
 
         self.assertEqual(len(metadata.tracks), 30)
 
@@ -143,16 +147,17 @@ class MetadataTestCase(unittest.TestCase):
         self.assertEqual(track8.artist, u'???')
         self.assertEqual(track8.sortName, u'[unknown]')
         self.assertEqual(track8.mbidArtist,
-                         u'125ec42a-7229-4250-afc5-e057484327fe')
+                         [u'125ec42a-7229-4250-afc5-e057484327fe'])
 
         track9 = metadata.tracks[8]
 
         self.assertEqual(track9.artist, u'CunninLynguists feat. Tonedeff')
         self.assertEqual(track9.sortName,
                          u'CunninLynguists feat. Tonedeff')
-        self.assertEqual(track9.mbidArtist,
-                         u'69c4cc43-8163-41c5-ac81-30946d27bb69'
-                         ';b3869d83-9fb5-4eac-b5ca-2d155fcbee12')
+        self.assertEqual(track9.mbidArtist, [
+            u'69c4cc43-8163-41c5-ac81-30946d27bb69',
+            u'b3869d83-9fb5-4eac-b5ca-2d155fcbee12'
+        ])
 
     def testNenaAndKimWildSingle(self):
         """
@@ -169,9 +174,10 @@ class MetadataTestCase(unittest.TestCase):
         metadata = mbngs._getMetadata(response['release'], discid)
         self.assertEqual(metadata.artist, u'Nena & Kim Wilde')
         self.assertEqual(metadata.release, u'2003-05-19')
-        self.assertEqual(metadata.mbidArtist,
-                         u'38bfaa7f-ee98-48cb-acd0-946d7aeecd76'
-                         ';4b462375-c508-432a-8c88-ceeec38b16ae')
+        self.assertEqual(metadata.mbidArtist, [
+            u'38bfaa7f-ee98-48cb-acd0-946d7aeecd76',
+            u'4b462375-c508-432a-8c88-ceeec38b16ae',
+        ])
 
         self.assertEqual(len(metadata.tracks), 4)
 
@@ -179,9 +185,10 @@ class MetadataTestCase(unittest.TestCase):
 
         self.assertEqual(track1.artist, u'Nena & Kim Wilde')
         self.assertEqual(track1.sortName, u'Nena & Wilde, Kim')
-        self.assertEqual(track1.mbidArtist,
-                         u'38bfaa7f-ee98-48cb-acd0-946d7aeecd76'
-                         ';4b462375-c508-432a-8c88-ceeec38b16ae')
+        self.assertEqual(track1.mbidArtist, [
+            u'38bfaa7f-ee98-48cb-acd0-946d7aeecd76',
+            u'4b462375-c508-432a-8c88-ceeec38b16ae',
+        ])
         self.assertEqual(track1.mbid,
                          u'1cc96e78-28ed-3820-b0b6-614c35b121ac')
         self.assertEqual(track1.mbidRecording,
@@ -191,9 +198,10 @@ class MetadataTestCase(unittest.TestCase):
 
         self.assertEqual(track2.artist, u'Nena & Kim Wilde')
         self.assertEqual(track2.sortName, u'Nena & Wilde, Kim')
-        self.assertEqual(track2.mbidArtist,
-                         u'38bfaa7f-ee98-48cb-acd0-946d7aeecd76'
-                         ';4b462375-c508-432a-8c88-ceeec38b16ae')
+        self.assertEqual(track2.mbidArtist, [
+            u'38bfaa7f-ee98-48cb-acd0-946d7aeecd76',
+            u'4b462375-c508-432a-8c88-ceeec38b16ae',
+        ])
         self.assertEqual(track2.mbid,
                          u'f16db4bf-9a34-3d5a-a975-c9375ab7a2ca')
         self.assertEqual(track2.mbidRecording,
@@ -223,7 +231,7 @@ class MetadataTestCase(unittest.TestCase):
         self.assertEqual(metadata.mbidReleaseGroup,
                          u'99850b41-a06e-4fb8-992c-75c191a77803')
         self.assertEqual(metadata.mbidArtist,
-                         u'4d56eb9f-13b3-4f05-9db7-50195378d49f')
+                         [u'4d56eb9f-13b3-4f05-9db7-50195378d49f'])
         self.assertEqual(metadata.url,
                          u'https://musicbrainz.org/release'
                          '/6109ceed-7e21-490b-b5ad-3a66b4e4cfbb')
@@ -240,7 +248,7 @@ class MetadataTestCase(unittest.TestCase):
                          u'4116eea3-b9c2-452a-8d63-92f1e585b225')
         self.assertEqual(track1.sortName, u'Rovics, David')
         self.assertEqual(track1.mbidArtist,
-                         u'4d56eb9f-13b3-4f05-9db7-50195378d49f')
+                         [u'4d56eb9f-13b3-4f05-9db7-50195378d49f'])
         self.assertEqual(track1.mbidRecording,
                          u'b191794d-b7c6-4d6f-971e-0a543959b5ad')
         self.assertEqual(track1.mbidWorks,


### PR DESCRIPTION
Instead of joining artist MBIDs with a ';' save them as multiple values to the tag. (This is how Picard saves that tag.)