### PR TITLE
WIP: Remove unused arguments for program.cdrdao.ReadTOCTask()

### DIFF
--- a/whipper/program/cdrdao.py
+++ b/whipper/program/cdrdao.py
@@ -1,11 +1,9 @@
 import os
 import re
-import shutil
 import tempfile
 import subprocess
 from subprocess import Popen, PIPE
 
-from whipper.common.common import truncate_filename
 from whipper.image.toc import TocFile
 from whipper.extern.task import task
 from whipper.extern import asyncsub
@@ -65,21 +63,15 @@ class ReadTOCTask(task.Task):
     description = "Reading TOC"
     toc = None
 
-    def __init__(self, device, fast_toc=False, toc_path=None):
+    def __init__(self, device):
         """
         Read the TOC for 'device'.
 
         @param device:  block device to read TOC from
         @type  device:  str
-        @param fast_toc:  If to use fast-toc cdrdao mode
-        @type  fast_toc: bool
-        @param toc_path: Where to save TOC if wanted.
-        @type  toc_path: str
         """
 
         self.device = device
-        self.fast_toc = fast_toc
-        self.toc_path = toc_path
         self._buffer = ""  # accumulate characters
         self._parser = ProgressParser()
 
@@ -91,9 +83,7 @@ class ReadTOCTask(task.Task):
         os.close(self.fd)
         os.unlink(self.tocfile)
 
-        cmd = ([CDRDAO, 'read-toc']
-               + (['--fast-toc'] if self.fast_toc else [])
-               + ['--device', self.device, self.tocfile])
+        cmd = ([CDRDAO, 'read-toc', '--device', self.device, self.tocfile])
 
         self._popen = asyncsub.Popen(cmd,
                                      bufsize=1024,
@@ -147,15 +137,6 @@ class ReadTOCTask(task.Task):
         self.setProgress(1.0)
         self.toc = TocFile(self.tocfile)
         self.toc.parse()
-        if self.toc_path is not None:
-            t_comp = os.path.abspath(self.toc_path).split(os.sep)
-            t_dirn = os.sep.join(t_comp[:-1])
-            # If the output path doesn't exist, make it recursively
-            if not os.path.isdir(t_dirn):
-                os.makedirs(t_dirn)
-            t_dst = truncate_filename(
-                os.path.join(t_dirn, t_comp[-1] + '.toc'))
-            shutil.copy(self.tocfile, os.path.join(t_dirn, t_dst))
         os.unlink(self.tocfile)
         self.stop()
         return


### PR DESCRIPTION
The one place the class is currently instanced, neither `fast_toc` nor `toc_path` is used, so there's hardly any reason to keep those around.