### PR TITLE
Use git to get whipper's version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     - sudo apt-get -qq update
     - sudo pip install --upgrade -qq pip
     - sudo apt-get -qq install cdparanoia cdrdao flac gir1.2-glib-2.0 libcdio-dev libiso9660-dev libsndfile1-dev python-cddb python-gi python-musicbrainzngs python-mutagen python-setuptools sox swig libcdio-utils
-    - sudo pip install pycdio==0.21 requests
+    - sudo pip install pycdio==0.21 requests setuptools_scm
 
     # Testing dependencies
     - sudo apt-get -qq install python-twisted-core

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mutagen
 pycdio>0.20
 PyGObject
 requests
+setuptools_scm

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,15 @@
 from setuptools import setup, find_packages
-from whipper import __version__ as whipper_version
 
 setup(
     name="whipper",
-    version=whipper_version,
+    use_scm_version=True,
     description="a secure cd ripper preferring accuracy over speed",
     author=['Thomas Vander Stichele', 'The Whipper Team'],
     maintainer=['The Whipper Team'],
     url='https://github.com/whipper-team/whipper',
     license='GPL3',
     packages=find_packages(),
+    setup_requires=['setuptools_scm'],
     entry_points={
         'console_scripts': [
             'whipper = whipper.command.main:main'

--- a/whipper/__init__.py
+++ b/whipper/__init__.py
@@ -2,7 +2,14 @@ import logging
 import os
 import sys
 
-__version__ = '0.7.3'
+from pkg_resources import (get_distribution,
+                           DistributionNotFound, RequirementParseError)
+try:
+    __version__ = get_distribution(__name__).version
+except (DistributionNotFound, RequirementParseError):
+    # not installed as package or is being run from source/git checkout
+    from setuptools_scm import get_version
+    __version__ = get_version()
 
 level = logging.INFO
 if 'WHIPPER_DEBUG' in os.environ:


### PR DESCRIPTION
This essentially a copy of code from spotify2musicbrainz: https://gitlab.com/Freso/spotify2musicbrainz/commit/59157165c4ca4e7bb1d5d8b081365029ddf55c72

Given that that code is in GPLv3 (and I'm its author :)), it should be fine to use. It is mostly boilerplate from upstream documentation anyway: https://pypi.org/project/setuptools-scm/

Should fix https://github.com/whipper-team/whipper/issues/337