### PR TITLE
Use Tox for easily testing with multiple Python interpreters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ whipper.egg-info/
 
 # From coverage report
 .coverage
+
+# tox cache
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 dist: xenial
 sudo: required
 
-language: bash
-
-env:
-    - FLAKE8=false
-    - FLAKE8=true
+language: python
+python:
+  - "2.7"
 
 install:
     # Dependencies
@@ -20,15 +18,14 @@ install:
     - ./configure
     - sudo make install
     - popd
-    
-    # Testing dependencies
-    - sudo pip install .[test,lint]
 
     # Build bundled C utils
     - pushd src
     - sudo make install
     - popd
+      #
+    # Testing dependencies
+    - sudo pip install tox-travis
 
-script:
-    - if [ ! "$FLAKE8" = true ]; then python -m unittest discover; fi
-    - if [ "$FLAKE8" = true ]; then flake8 --benchmark --statistics; fi
+
+script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: required
 
 language: bash
@@ -10,20 +11,23 @@ install:
     # Dependencies
     - sudo apt-get -qq update
     - sudo pip install --upgrade -qq pip
-    - sudo apt-get -qq install cdparanoia cdrdao flac gir1.2-glib-2.0 libcdio-dev libiso9660-dev libsndfile1-dev python-gi python-musicbrainzngs python-mutagen python-setuptools sox swig libcdio-utils
-    - sudo pip install pycdio==0.21 requests setuptools_scm
+    - sudo apt-get -qq install cdparanoia cdrdao flac libgirepository1.0-dev gir1.2-glib-2.0 libiso9660-dev libsndfile1-dev python-cddb sox swig libcdio-utils
 
+    # Travis' Ubuntu is very old, libcdio needs to be compiled
+    - wget https://ftp.gnu.org/gnu/libcdio/libcdio-2.0.0.tar.gz
+    - tar -xvzf libcdio-2.0.0.tar.gz
+    - pushd libcdio-2.0.0
+    - ./configure
+    - sudo make install
+    - popd
+    
     # Testing dependencies
-    - sudo apt-get -qq install python-twisted-core
-    - sudo pip install flake8
+    - sudo pip install .[test,lint]
 
     # Build bundled C utils
-    - cd src
+    - pushd src
     - sudo make install
-    - cd ..
-
-    # Installing
-    - sudo python setup.py install
+    - popd
 
 script:
     - if [ ! "$FLAKE8" = true ]; then python -m unittest discover; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 FROM debian:buster
 
 RUN apt-get update \
-  && apt-get install -y cdrdao python-gobject-2 python-musicbrainzngs python-mutagen python-setuptools \
-  python-requests libsndfile1-dev flac sox \
-  libiso9660-dev python-pip swig make pkgconf \
+  && apt-get install -y cdrdao libcairo2-dev python-cddb libsndfile1-dev flac sox \
+  libiso9660-dev python-pip swig make pkgconf git \
   eject locales \
-  autoconf libtool curl \
-  && pip install pycdio==2.0.0
+  autoconf libtool curl
 
 # libcdio-paranoia / libcdio-utils are wrongfully packaged in Debian, thus built manually
 # see https://github.com/whipper-team/whipper/pull/237#issuecomment-367985625
@@ -24,7 +22,7 @@ RUN curl -o - 'https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-10.2+0.94+2.tar.
   && autoreconf -fi \
   && ./configure --disable-dependency-tracking --disable-example-progs --disable-static \
   && make install \
-  && cd .. \ 
+  && cd .. \
   && rm -rf libcdio-paranoia-10.2+0.94+2
 
 RUN ldconfig
@@ -46,7 +44,7 @@ RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment \
 RUN mkdir /whipper
 COPY . /whipper/
 RUN cd /whipper/src && make && make install \
-  && cd /whipper && python2 setup.py install \
+  && cd /whipper && python2 -m pip install --no-cache-dir . \
   && rm -rf /whipper \
   && whipper -v
 

--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ Some dependencies aren't available in the PyPI. They can be probably installed u
 - [flac](https://xiph.org/flac/)
 - [sox](http://sox.sourceforge.net/)
 
-PyPI installable dependencies are listed in the [requirements.txt](https://github.com/whipper-team/whipper/blob/master/requirements.txt) file and can be installed issuing the following command:
+PyPI installable dependencies are listed in the [setup.py](https://github.com/whipper-team/whipper/blob/master/setup.py) file and they are installed automatically when installing whipper with pip:
 
-`pip install -r requirements.txt`
+`python2 -m pip install -e .`
 
 ### Fetching the source code
 
@@ -171,9 +171,7 @@ cd ..
 
 ### Finalizing the build
 
-Install whipper: `python2 setup.py install`
-
-Note that, depending on the chosen installation path, this command may require elevated rights.
+Install whipper: `python2 -m pip install --user .`
 
 ## Usage
 
@@ -257,13 +255,12 @@ disc_template =  new/%%A/%%y - %%d/%%A - %%d
 # ...
 ```
 
-## Running uninstalled
+## Developing
 
-To make it easier for developers, you can run whipper straight from the
-source checkout:
+To make it easier for developers, whipper can be installed in live mode:
 
 ```bash
-python2 -m whipper -h
+python2 -m pip install --user -e .
 ```
 
 ## Logger plugins

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-musicbrainzngs
-mutagen
-pycdio>0.20
-PyGObject
-requests
-setuptools_scm

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,14 @@
 from setuptools import setup, find_packages
 
+INSTALL_DEPS = [
+    'musicbrainzngs',
+    'mutagen',
+    'pycdio>0.20',
+    'PyGObject',
+    'requests']
+TEST_DEPS = ['Twisted']
+LINT_DEPS = ['flake8']
+
 setup(
     name="whipper",
     use_scm_version=True,
@@ -18,4 +27,10 @@ setup(
     data_files=[
         ('share/metainfo', ['com.github.whipper_team.Whipper.metainfo.xml']),
     ],
+    python_requires='>=2.7, <3',
+    install_requires=INSTALL_DEPS,
+    extras_require={
+        'test': TEST_DEPS,
+        'lint': LINT_DEPS
+    },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist =
+  py{27,34,35,36,37,py,py3}-unit,
+  py{27,34,35,36,37,py,py3}-lint,
+skip_missing_interpreters = True
+
+[testenv]
+passenv = CI TRAVIS TRAVIS_*
+extras =
+  py{27,34,35,36,37,py,py3}-unit: test
+  py{27,34,35,36,37,py,py3}-lint: lint
+commands =
+  py{27,34,35,36,37,py,py3}-unit: python -m unittest discover
+  py{27,34,35,36,37,py,py3}-lint: python -m flake8 --benchmark --statistics
+ignore_outcome =
+  py{27,34,35,36,37,py,py3}-lint: True


### PR DESCRIPTION
[Tox](https://tox.readthedocs.io/en/latest/) makes it very easy to test packages in customized virtual environments.

I thought it would be useful to be able to test the package in preparation for python 3 compatibility: #78 

Right now there are 2 tests failing: one fails because some url parameters are out of order and the other one I need to investigate further, seems like the environment cannot access cdrdao

Let me know if  you like this approach so I can continue working on this. In the end if the developers don't use it, there's not much point in doing this.