### PR TITLE
Specify supported version(s) of Python in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     maintainer=['The Whipper Team'],
     url='https://github.com/whipper-team/whipper',
     license='GPL3',
+    python_requires='>=2.7,<3',
     packages=find_packages(),
     setup_requires=['setuptools_scm'],
     entry_points={


### PR DESCRIPTION
In preparation for [dropping Python 2.7 support](https://github.com/whipper-team/whipper/issues/78), this specifies versions that *are* compatible with Python 2.7, so anyone installing via pip (if we end up publishing to PyPI) will get the proper version.

See https://packaging.python.org/guides/dropping-older-python-versions/