### PR TITLE
Include MusicBrainz Release URL in log output

### DIFF
--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -182,6 +182,7 @@ class _CD(BaseCommand):
         _, self.program.result.vendor, self.program.result.model, \
             self.program.result.release = \
             cdio.Device(self.device).get_hwinfo()
+        self.program.result.metadata = self.program.metadata
 
         self.doCommand()
 

--- a/whipper/result/logger.py
+++ b/whipper/result/logger.py
@@ -70,10 +70,10 @@ class WhipperLogger(result.Logger):
         lines.append("  CDDB Disc ID: %s" % ripResult. table.getCDDBDiscId())
         lines.append("  MusicBrainz Disc ID: %s" %
                      ripResult. table.getMusicBrainzDiscId())
-        lines.append("  MusicBrainz lookup url: %s" %
+        lines.append("  MusicBrainz lookup URL: %s" %
                      ripResult. table.getMusicBrainzSubmitURL())
         if ripResult.metadata:
-            lines.append("  MusicBrainz Release url: %s" %
+            lines.append("  MusicBrainz Release URL: %s" %
                          ripResult.metadata.url)
         lines.append("")
 

--- a/whipper/result/logger.py
+++ b/whipper/result/logger.py
@@ -72,6 +72,9 @@ class WhipperLogger(result.Logger):
                      ripResult. table.getMusicBrainzDiscId())
         lines.append("  MusicBrainz lookup url: %s" %
                      ripResult. table.getMusicBrainzSubmitURL())
+        if ripResult.metadata:
+            lines.append("  MusicBrainz Release url: %s" %
+                         ripResult.metadata.url)
         lines.append("")
 
         # TOC section

--- a/whipper/result/result.py
+++ b/whipper/result/result.py
@@ -72,6 +72,8 @@ class RipResult:
     @ivar offset: sample read offset
     @ivar table:  the full index table
     @type table:  L{whipper.image.table.Table}
+    @ivar metadata: disc metadata from MusicBrainz (if available)
+    @type metadata: L{whipper.common.mbngs.DiscMetadata}
 
     @ivar vendor:  vendor of the CD drive
     @ivar model:   model of the CD drive
@@ -88,6 +90,7 @@ class RipResult:
     table = None
     artist = None
     title = None
+    metadata = None
 
     vendor = None
     model = None


### PR DESCRIPTION
This also passes *all* metadata to the `result` object, giving loggers a lot more (release) metadata to work with, in case custom, “3rd party” loggers (or even ourselves in the future!) want to do something more fancy or expansive with the metadata in the log file.

Fixes https://github.com/whipper-team/whipper/issues/381