### PR TITLE
Use PyYAML for formatting the rip .log file

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Whipper relies on the following packages in order to run correctly and provide a
 - [python-requests](https://pypi.python.org/pypi/requests), for retrieving AccurateRip database entries
 - [pycdio](https://pypi.python.org/pypi/pycdio/), for drive identification (required for drive offset and caching behavior to be stored in the configuration file).
   - To avoid bugs  it's advised to use `pycdio` **0.20** or **0.21** with `libcdio` ≥ **0.90** ≤ **0.94* or `pycdio` **2.0.0** with `libcdio` **2.0.0**. All other combinations won't probably work.
+- [PyYAML](https://pyyaml.org/wiki/PyYAML), for the standard rip logger
 - [libsndfile](http://www.mega-nerd.com/libsndfile/), for reading wav files
 - [flac](https://xiph.org/flac/), for reading flac files
 - [sox](http://sox.sourceforge.net/), for track peak detection

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ musicbrainzngs
 mutagen
 pycdio>0.20
 PyGObject
+pyyaml
 requests
 setuptools_scm


### PR DESCRIPTION
The .log file is intended to be in YAML, but until now we have "manually" formatted this output, which is prone to errors.

This new approach generates a dictionary containing the log information and then calls to PyYAML's YAML implementation to format it out to a string which can then be saved to a file.

Note that key order of dictionaries prior to Python 3.7 is non-deterministic (or not guaranteed to be) and thus may need further tweaking.
Also, PyYAML presently only supports YAML 1.1. It may be needed/wanted to switch to [ruamel.yaml](https://yaml.readthedocs.io/) instead for YAML 1.2 support.