### PR TITLE
Use eject value of the class again

### DIFF
--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -186,7 +186,8 @@ class _CD(BaseCommand):
 
         self.doCommand()
 
-        if self.options.eject in ('success', 'always'):
+        if (self.options.eject == 'success' and self.eject or
+                self.options.eject == 'always'):
             utils.eject_device(self.device)
 
         return None


### PR DESCRIPTION
The variable `self.eject` was used before https://github.com/whipper-team/whipper/pull/93 to decide if the disc should be ejected.

This PR introduces this functionality again.

In correspondence to https://github.com/whipper-team/whipper/pull/392, the disc will still be ejected when the parameter `--eject` is set to `always` but not if `--eject` is set to `success` during `whipper cd info`.

(Fixes: comment in #375)

