### PR TITLE
Set default for eject to: success

### DIFF
--- a/whipper/command/main.py
+++ b/whipper/command/main.py
@@ -102,10 +102,10 @@ class Whipper(BaseCommand):
                                  help="show this help message and exit")
         self.parser.add_argument('-e', '--eject',
                                  action="store", dest="eject",
-                                 default="always",
+                                 default="success",
                                  choices=('never', 'failure',
                                           'success', 'always'),
-                                 help="when to eject disc (default: always)")
+                                 help="when to eject disc (default: success)")
 
     def handle_arguments(self):
         if self.options.help:


### PR DESCRIPTION
Currently, the value `success` for ejecting the disc doesn't have a meaning.

I would interpret it as `eject the disc after successful rip` (and not after whipper cd info). As a user, I would expect this is the default and not eject the disc after every everything (aka `always`).