### PR TITLE
Use YAML 1.2 boolean values for generated log files

### DIFF
--- a/whipper/result/logger.py
+++ b/whipper/result/logger.py
@@ -40,26 +40,24 @@ class WhipperLogger(result.Logger):
         lines.append("  Extraction engine: cdparanoia %s" %
                      ripResult.cdparanoiaVersion)
         if ripResult.cdparanoiaDefeatsCache is None:
-            defeat = "Unknown"
+            defeat = "null"
         elif ripResult.cdparanoiaDefeatsCache:
-            defeat = "Yes"
+            defeat = "true"
         else:
-            defeat = "No"
+            defeat = "false"
         lines.append("  Defeat audio cache: %s" % defeat)
         lines.append("  Read offset correction: %+d" % ripResult.offset)
         # Currently unsupported by the official cdparanoia package
-        over = "No"
+        over = "false"
         # Only implemented in whipper (ripResult.overread)
         if ripResult.overread:
-            over = "Yes"
+            over = "true"
         lines.append("  Overread into lead-out: %s" % over)
         # Next one fully works only using the patched cdparanoia package
-        # lines.append("Fill up missing offset samples with silence: Yes")
+        # lines.append("Fill up missing offset samples with silence: true")
         lines.append("  Gap detection: cdrdao %s" % ripResult.cdrdaoVersion)
-        if ripResult.isCdr:
-            isCdr = "Yes"
-        else:
-            isCdr = "No"
+
+        isCdr = "true" if ripResult.isCdr else "false"
         lines.append("  CD-R detected: %s" % isCdr)
         lines.append("")
 
@@ -184,10 +182,7 @@ class WhipperLogger(result.Logger):
 
         # Pre-emphasis status
         # Only implemented in whipper (trackResult.pre_emphasis)
-        if trackResult.pre_emphasis:
-            preEmph = "Yes"
-        else:
-            preEmph = "No"
+        preEmph = "true" if trackResult.pre_emphasis else "false"
         lines.append("    Pre-emphasis: %s" % preEmph)
 
         # Extraction speed


### PR DESCRIPTION
The current log files are generated using values that are considered booleans under [YAML 1.1](https://yaml.org/type/bool.html), but not [YAML 1.2](https://yaml.org/spec/1.2/spec.html#id2803629). 

This makes the generated logs use the standard boolean values of `true`/`false` instead of `Yes`/`No` so that the logs are parsed the same under both YAML 1.1 and 1.2 into booleans which is going to be less surprising to downstream automated consumers of these logs.

The main point of contention I would see is that "Defeat audio cache" was changed from `Unknown`/`Yes`/`No` to `null`/`true`/`false`. All of the others were strict booleans (could only be true or false).

Example:
```
import yaml# PyYAML, uses YAML 1.1
from ruamel.yaml import YAML # uses YAML 1.2

ruamel_yaml = YAML(saf=True)

with open('whipper_test.log') as open_file:
    log = open_file.read()

print(yaml.safe_load(log)['Ripping phase information']['Defeat audio cache']) # True
print(ruamel_yaml.load(log)['Ripping phase information']['Defeat audio cache']) # Yes
```

This follows from the discussion in #384 around this.