### PR TITLE
Fix offset find command

### DIFF
--- a/whipper/command/offset.py
+++ b/whipper/command/offset.py
@@ -85,7 +85,8 @@ CD in the AccurateRip database."""
 
         # first get the Table Of Contents of the CD
         t = cdrdao.ReadTOCTask(device)
-        table = t.table
+        runner.run(t)
+        table = t.toc.table
 
         logger.debug("CDDB disc id: %r", table.getCDDBDiscId())
         try:


### PR DESCRIPTION
The refactoring of `ReadTOCTask` in commit 3e79032b63d25d7f2d66a73ad31f9c2db91d390c
broke the `offset find` command. This commit fixes it again.

Signed-off-by: Volker Mische <volker.mische@gmail.com>