### PR TITLE
Handle missing self.options for whipper cd info

### DIFF
--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -134,20 +134,23 @@ class _CD(BaseCommand):
             return -1
 
         # Change working directory before cdrdao's task
-        if self.options.working_directory is not None:
+        if getattr(self.options, 'working_directory', False):
             os.chdir(os.path.expanduser(self.options.working_directory))
-        out_bpath = self.options.output_directory.decode('utf-8')
-        # Needed to preserve cdrdao's tocfile
-        out_fpath = self.program.getPath(out_bpath,
-                                         self.options.disc_template,
-                                         self.mbdiscid,
-                                         self.program.metadata)
+        if hasattr(self.options, 'output_directory'):
+            out_bpath = self.options.output_directory.decode('utf-8')
+            # Needed to preserve cdrdao's tocfile
+            out_fpath = self.program.getPath(out_bpath,
+                                             self.options.disc_template,
+                                             self.mbdiscid,
+                                             self.program.metadata)
+        else:
+            out_fpath = None
         # now, read the complete index table, which is slower
+        offset = getattr(self.options, 'offset', 0)
         self.itable = self.program.getTable(self.runner,
                                             self.ittoc.getCDDBDiscId(),
                                             self.ittoc.getMusicBrainzDiscId(),
-                                            self.device, self.options.offset,
-                                            out_fpath)
+                                            self.device, offset, out_fpath)
 
         assert self.itable.getCDDBDiscId() == self.ittoc.getCDDBDiscId(), \
             "full table's id %s differs from toc id %s" % (


### PR DESCRIPTION
The attributes `working_directory`, `disc_template`, `output_directory` and `offset` are not defined during `whipper cd info` and they are only needed for ripping, and `self.program.getTable` doesn't need `output_path` to gather the tocfile.

Therefore, this part is excluded, if the attributes don't exist and an offset of 0 is used.

(Not tested yet. But I expect that it will work.)

Fixes issue #375.