### PR TITLE
Use ruamel.yaml for formatting and outputting rip .log file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,10 @@ install:
     - sudo apt-get -qq update
     - pip install --upgrade -qq pip
     - sudo apt-get -qq install cdparanoia cdrdao flac gir1.2-glib-2.0 libcdio-dev libgirepository1.0-dev libiso9660-dev libsndfile1-dev sox swig libcdio-utils
-    - pip install musicbrainzngs mutagen pycdio==0.21 PyGObject requests setuptools setuptools_scm
+    # newer version of pydcio requires newer version of libcdio than travis has
+    - pip install pycdio==0.21
+    # install rest of dependencies
+    - pip install -r requirements.txt
 
     # Testing dependencies
     - pip install twisted flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ mutagen
 pycdio>0.20
 PyGObject
 requests
+ruamel.yaml
 setuptools_scm

--- a/whipper/test/test_result_logger.log
+++ b/whipper/test/test_result_logger.log
@@ -1,0 +1,80 @@
+Log created by: whipper 0.7.4.dev87+gb71ec9f.d20191026 (internal logger)
+Log creation date: 2019-10-26T14:25:02Z
+
+Ripping phase information:
+  Drive: HL-DT-STBD-RE  WH14NS40 (revision 1.03)
+  Extraction engine: cdparanoia cdparanoia III 10.2 libcdio 2.0.0 x86_64-pc-linux-gnu
+  Defeat audio cache: true
+  Read offset correction: 6
+  Overread into lead-out: false
+  Gap detection: cdrdao 1.2.4
+  CD-R detected: false
+
+CD metadata:
+  Release:
+    Artist: Example - Symbol - Artist
+    Title: 'Album With: - Dashes'
+  CDDB Disc ID: c30bde0d
+  MusicBrainz Disc ID: eyjySLXGdKigAjY3_C0nbBmNUHc-
+  MusicBrainz lookup URL: https://musicbrainz.org/cdtoc/attach?toc=1+13+228039+150+16414+33638+51378+69369+88891+104871+121645+138672+160748+178096+194680+212628&tracks=13&id=eyjySLXGdKigAjY3_C0nbBmNUHc-
+
+TOC:
+  1:
+    Start: 00:00:00
+    Length: 03:36:64
+    Start sector: 0
+    End sector: 16263
+
+  2:
+    Start: 03:36:64
+    Length: 03:49:49
+    Start sector: 16264
+    End sector: 33487
+
+Tracks:
+  1:
+    Filename: ./soundtrack/Various Artists - Shark Tale - Motion Picture Soundtrack/01. Sean Paul & Ziggy Marley - Three Little Birds.flac
+    Peak level: 0.90036
+    Pre-emphasis:
+    Extraction speed: 7.0 X
+    Extraction quality: 100.00 %
+    Test CRC: 0025D726
+    Copy CRC: 0025D726
+    AccurateRip v1:
+      Result: Found, exact match
+      Confidence: 14
+      Local CRC: 95E6A189
+      Remote CRC: 95E6A189
+    AccurateRip v2:
+      Result: Found, exact match
+      Confidence: 11
+      Local CRC: 113FA733
+      Remote CRC: 113FA733
+    Status: Copy OK
+
+  2:
+    Filename: ./soundtrack/Various Artists - Shark Tale - Motion Picture Soundtrack/02. Christina Aguilera feat. Missy Elliott - Car Wash (Shark Tale mix).flac
+    Peak level: 0.972351
+    Pre-emphasis:
+    Extraction speed: 7.7 X
+    Extraction quality: 100.00 %
+    Test CRC: F77C14CB
+    Copy CRC: F77C14CB
+    AccurateRip v1:
+      Result: Found, exact match
+      Confidence: 14
+      Local CRC: 0B3316DB
+      Remote CRC: 0B3316DB
+    AccurateRip v2:
+      Result: Found, exact match
+      Confidence: 10
+      Local CRC: A0AE0E57
+      Remote CRC: A0AE0E57
+    Status: Copy OK
+
+Conclusive status report:
+  AccurateRip summary: All tracks accurately ripped
+  Health Status: No errors occurred
+  EOF: End of status report
+
+SHA-256 hash: 2B176D8C722989B25459160E335E5CC0C1A6813C9DA69F869B625FBF737C475E

--- a/whipper/test/test_result_logger.py
+++ b/whipper/test/test_result_logger.py
@@ -1,0 +1,169 @@
+from __future__ import print_function
+import hashlib
+import os
+import re
+import unittest
+import ruamel.yaml
+
+from whipper.result.result import TrackResult, RipResult
+from whipper.result.logger import WhipperLogger
+
+
+class MockImageTrack:
+    def __init__(self, number, start, end):
+        self.number = number
+        self.absolute = self.start = start
+        self.end = end
+
+    def getIndex(self, num):
+        if num == 0:
+            raise KeyError
+        else:
+            return self
+
+
+class MockImageTable:
+    """Mock of whipper.image.table.Table, with fake information."""
+    def __init__(self):
+        self.tracks = [
+            MockImageTrack(1, 0,  16263),
+            MockImageTrack(2, 16264, 33487)
+        ]
+
+    def getCDDBDiscId(self):
+        return "c30bde0d"
+
+    def getMusicBrainzDiscId(self):
+        return "eyjySLXGdKigAjY3_C0nbBmNUHc-"
+
+    def getMusicBrainzSubmitURL(self):
+        return (
+            "https://musicbrainz.org/cdtoc/attach?toc=1+13+228039+150+16414+"
+            "33638+51378+69369+88891+104871+121645+138672+160748+178096+194680"
+            "+212628&tracks=13&id=eyjySLXGdKigAjY3_C0nbBmNUHc-"
+        )
+
+    def getTrackLength(self, number):
+        return self.tracks[number-1].end - self.tracks[number-1].start + 1
+
+    def getTrackEnd(self, number):
+        return self.tracks[number-1].end
+
+
+class LoggerTestCase(unittest.TestCase):
+    def setUp(self):
+        self.path = os.path.join(os.path.dirname(__file__))
+
+    def testLogger(self):
+        ripResult = RipResult()
+        ripResult.offset = 6
+        ripResult.overread = False
+        ripResult.isCdr = False
+        ripResult.table = MockImageTable()
+        ripResult.artist = "Example - Symbol - Artist"
+        ripResult.title = "Album With: - Dashes"
+        ripResult.vendor = "HL-DT-STBD-RE  "
+        ripResult.model = "WH14NS40"
+        ripResult.release = "1.03"
+        ripResult.cdrdaoVersion = "1.2.4"
+        ripResult.cdparanoiaVersion = (
+            "cdparanoia III 10.2 "
+            "libcdio 2.0.0 x86_64-pc-linux-gnu"
+        )
+        ripResult.cdparanoiaDefeatsCache = True
+
+        trackResult = TrackResult()
+        trackResult.number = 1
+        trackResult.filename = (
+            "./soundtrack/Various Artists - Shark Tale - Motion Picture "
+            "Soundtrack/01. Sean Paul & Ziggy Marley - Three Little Birds.flac"
+        )
+        trackResult.pregap = 0
+        trackResult.peak = 29503
+        trackResult.quality = 1
+        trackResult.copyspeed = 7
+        trackResult.testduration = 10
+        trackResult.copyduration = 10
+        trackResult.testcrc = 0x0025D726
+        trackResult.copycrc = 0x0025D726
+        trackResult.AR = {
+            "v1": {
+                "DBConfidence": 14,
+                "DBCRC": "95E6A189",
+                "CRC": "95E6A189"
+            },
+            "v2": {
+                "DBConfidence": 11,
+                "DBCRC": "113FA733",
+                "CRC": "113FA733"
+            }
+        }
+        ripResult.tracks.append(trackResult)
+
+        trackResult = TrackResult()
+        trackResult.number = 2
+        trackResult.filename = (
+            "./soundtrack/Various Artists - Shark Tale - Motion Picture "
+            "Soundtrack/02. Christina Aguilera feat. Missy Elliott - Car "
+            "Wash (Shark Tale mix).flac"
+        )
+        trackResult.pregap = 0
+        trackResult.peak = 31862
+        trackResult.quality = 1
+        trackResult.copyspeed = 7.7
+        trackResult.testduration = 10
+        trackResult.copyduration = 10
+        trackResult.testcrc = 0xF77C14CB
+        trackResult.copycrc = 0xF77C14CB
+        trackResult.AR = {
+            "v1": {
+                "DBConfidence": 14,
+                "DBCRC": "0B3316DB",
+                "CRC": "0B3316DB"
+            },
+            "v2": {
+                "DBConfidence": 10,
+                "DBCRC": "A0AE0E57",
+                "CRC": "A0AE0E57"
+            }
+        }
+        ripResult.tracks.append(trackResult)
+        logger = WhipperLogger()
+        actual = logger.log(ripResult)
+        actualLines = actual.splitlines()
+        expectedLines = open(
+            os.path.join(self.path, 'test_result_logger.log'), 'r'
+        ).read().splitlines()
+        # do not test on version line, date line, or SHA-256 hash line
+        self.assertListEqual(actualLines[2:-1], expectedLines[2:-1])
+
+        self.assertRegexpMatches(
+            actualLines[0],
+            re.compile((
+                r'Log created by: whipper '
+                r'[\d]+\.[\d]+.[\d]+\.dev[\w\.\+]+ \(internal logger\)'
+            ))
+        )
+        self.assertRegexpMatches(
+            actualLines[1],
+            re.compile((
+                r'Log creation date: '
+                r'20[\d]{2}\-[\d]{2}\-[\d]{2}T[\d]{2}:[\d]{2}:[\d]{2}Z'
+            ))
+        )
+
+        yaml = ruamel.yaml.YAML()
+        parsedLog = yaml.load(actual)
+        self.assertEqual(
+            actual,
+            ruamel.yaml.dump(
+                parsedLog,
+                default_flow_style=False,
+                width=4000,
+                Dumper=ruamel.yaml.RoundTripDumper
+            )
+        )
+        self.assertEqual(
+            parsedLog['SHA-256 hash'],
+            hashlib.sha256("\n".join(actualLines[:-1])).hexdigest().upper()
+        )


### PR DESCRIPTION
Similar to #384, but uses [ruamel.yaml](https://pypi.org/project/ruamel.yaml/) instead producing a YAML 1.2 compliant log, while retaining the ordering of they keys. There's still some steps of cleanup for values (handful of `"%s"` and `"%d"` replaces that can just use the value directly) and then matter of newlines in the log.

Here is a test script for checking the output of the logger (relies on having [box](https://pypi.org/project/python-box/)), without having to actually rip a CD:
```
from __future__ import print_function
from box import Box
import ruamel.yaml
from whipper.result.logger import WhipperLogger


class Track(object):
    def __init__(self, number, start, end):
        self.number = number
        self.absolute = self.start = start
        self.end = end

    def getIndex(self, num):
        if num == 0:
            raise KeyError
        else:
            return self


class Table(object):
    def __init__(self):
        self.tracks = [
            Track(1, 0,  16263),
            Track(2, 16264, 33487)
        ]

    def getCDDBDiscId(self):
        return "c30bde0d"

    def getMusicBrainzDiscId(self):
        return "eyjySLXGdKigAjY3_C0nbBmNUHc-"

    def getMusicBrainzSubmitURL(self):
        return "https://musicbrainz.org/cdtoc/attach?toc=1+13+228039+150+16414+33638+51378+69369+88891+104871+121645+138672+160748+178096+194680+212628&tracks=13&id=eyjySLXGdKigAjY3_C0nbBmNUHc-"

    def getTrackLength(self, number):
        return self.tracks[number-1].end - self.tracks[number-1].start + 1

    def getTrackEnd(self, number):
        return self.tracks[number-1].end


ripResult = {
    "vendor": "HL-DT-STBD-RE  ",
    "model": "WH14NS40",
    "release": "1.03",
    "cdparanoiaVersion": "cdparanoia III 10.2 libcdio 2.0.0 x86_64-pc-linux-gnu",
    "cdparanoiaDefeatsCache": True,
    "offset": 6,
    "overread": True,
    "cdrdaoVersion": "1.2.4",
    "isCdr": False,
    "artist": "Various Artists",
    "title": "Shark Tale: Motion Picture Soundtrack",
    "table": Table(),
    "metadata": False,
    #     "url": ""
    # },
    "tracks": [
        {
            "number": 1,
            "filename": "./soundtrack/Various Artists - Shark Tale - Motion Picture Soundtrack/01. Sean Paul & Ziggy Marley - Three Little Birds.flac",
            "pregap": False,
            "peak": 29503,
            "pre_emphasis": False,
            "copyspeed": 7,
            "quality": 1,
            "testcrc": 0x0025D726,
            "copycrc": 0x0025D726,
            "AR": {
                "v1": {
                    "DBConfidence": 14,
                    "DBCRC": "95E6A189",
                    "CRC": "95E6A189"
                },
                "v2": {
                    "DBConfidence": 11,
                    "DBCRC": "113FA733",
                    "CRC": "113FA733"
                }
            },
            "testduration": 10,
            "copyduration": 10
        },
        {
            "number": 2,
            "filename": "./soundtrack/Various Artists - Shark Tale - Motion Picture Soundtrack/02. Christina Aguilera feat. Missy Elliott - Car Wash (Shark Tale mix).flac",
            "pregap": False,
            "peak": 31862,
            "pre_emphasis": False,
            "copyspeed": 7.7,
            "quality": 1,
            "testcrc": 0xF77C14CB,
            "copycrc": 0xF77C14CB,
            "AR": {
                "v1": {
                    "DBConfidence": 14,
                    "DBCRC": "0B3316DB",
                    "CRC": "0B3316DB"
                },
                "v2": {
                    "DBConfidence": 10,
                    "DBCRC": "A0AE0E57",
                    "CRC": "A0AE0E57"
                }
            },
            "testduration": 10,
            "copyduration": 10
        }
    ]
}

ripResult = Box(ripResult)


logger = WhipperLogger()
result = logger.log(ripResult)
print(result)
yaml = ruamel.yaml.YAML()
ruamel.yaml.dump(yaml.load(result))
```