### PR TITLE
Make getFastToc() fast again

### DIFF
--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -443,17 +443,17 @@ Log files will log the path to tracks relative to this directory.
                     logger.debug('HTOA peak %r is equal to the SILENT '
                                  'threshold, disregarding', trackResult.peak)
                     self.itable.setFile(1, 0, None,
-                                        self.ittoc.getTrackStart(1), number)
+                                        self.itable.getTrackStart(1), number)
                     logger.debug('unlinking %r', trackResult.filename)
                     os.unlink(trackResult.filename)
                     trackResult.filename = None
                     logger.info('HTOA discarded, contains digital silence')
                 else:
                     self.itable.setFile(1, 0, trackResult.filename,
-                                        self.ittoc.getTrackStart(1), number)
+                                        self.itable.getTrackStart(1), number)
             else:
                 self.itable.setFile(number, 1, trackResult.filename,
-                                    self.ittoc.getTrackLength(number), number)
+                                    self.itable.getTrackLength(number), number)
 
             self.program.saveRipResult()
 
@@ -482,7 +482,7 @@ Log files will log the path to tracks relative to this directory.
         self.program.write_m3u(discName)
 
         try:
-            self.program.verifyImage(self.runner, self.ittoc)
+            self.program.verifyImage(self.runner, self.itable)
         except accurip.EntryNotFound:
             logger.warning('AccurateRip entry not found')
 

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -96,7 +96,7 @@ class Program:
             logger.warning('cdrdao older than 1.2.3 has a pre-gap length bug.'
                            ' See http://sourceforge.net/tracker/?func=detail&aid=604751&group_id=2171&atid=102171')  # noqa: E501
 
-        t = cdrdao.ReadTOCTask(device)
+        t = cdrdao.ReadTOCTask(device, fast_toc=True)
         runner.run(t)
         toc = t.toc.table
 


### PR DESCRIPTION
AFAICS, the fast TOC code-path served the following purposes:
- Create IDs for MusicBrainz and CDDB lookup.
- Use these IDs as an index into the TOC cache to quickly resume or restart unfinished rips.

Since #345 broke it, each rip ran the slow TOC code-path twice, resulting in needlessly slow rips and a useless caching mechanism.

This PR restores the previous behaviour.

The first commit just intends to make clear that data from the thorough TOC read is preferred over the data from fast TOC reads.

Please do not discuss whether slow TOC reads are useful here. It's a different issue. This is just a bug fix.