### PR TITLE
test_result_logger: accept release version numbers

### DIFF
--- a/whipper/test/test_result_logger.py
+++ b/whipper/test/test_result_logger.py
@@ -141,7 +141,7 @@ class LoggerTestCase(unittest.TestCase):
             actualLines[0],
             re.compile((
                 r'Log created by: whipper '
-                r'[\d]+\.[\d]+.[\d]+\.dev[\w\.\+]+ \(internal logger\)'
+                r'[\d]+\.[\d]+.[\d]+(\.dev[\w\.\+]+)? \(internal logger\)'
             ))
         )
         self.assertRegexpMatches(


### PR DESCRIPTION
When building on release, the output version is e.g. 0.8.0, without dev part.
Thus, this commit makes the dev part optional, allowing it to match both cases.
Fixes GH-420.