### PR TITLE
Enable whipper to use track title

### DIFF
--- a/whipper/common/mbngs.py
+++ b/whipper/common/mbngs.py
@@ -247,7 +247,7 @@ def _getMetadata(release, discid, country=None):
                     track.sortName = trackCredit.getSortName()
                     track.mbidArtist = trackCredit.getIds()
 
-                    track.title = t['recording']['title']
+                    track.title = t.get('title', t['recording']['title'])
                     track.mbid = t['id']
                     track.mbidRecording = t['recording']['id']
                     track.mbidWorks = _getWorks(t['recording'])

--- a/whipper/test/test_common_mbngs.py
+++ b/whipper/test/test_common_mbngs.py
@@ -26,6 +26,24 @@ class MetadataTestCase(unittest.TestCase):
 
         self.assertFalse(metadata.release)
 
+    def testTrackTitle(self):
+        """
+        Check that the track title metadata is taken from MusicBrainz's track
+        title (which may differ from the recording title, as in this case)
+        see https://github.com/whipper-team/whipper/issues/192
+        """
+        # Using: The KLF - Space & Chill Out
+        # https://musicbrainz.org/release/c56ff16e-1d81-47de-926f-ba22891bd2bd
+        filename = 'whipper.release.c56ff16e-1d81-47de-926f-ba22891bd2bd.json'
+        path = os.path.join(os.path.dirname(__file__), filename)
+        with open(path, "rb") as handle:
+            response = json.loads(handle.read().decode('utf-8'))
+        discid = "b.yqPuCBdsV5hrzDvYrw52iK_jE-"
+
+        metadata = mbngs._getMetadata(response['release'], discid)
+        track1 = metadata.tracks[0]
+        self.assertEqual(track1.title, 'Brownsville Turnaround')
+
     def test2MeterSessies10(self):
         # various artists, multiple artists per track
         filename = 'whipper.release.a76714e0-32b1-4ed4-b28e-f86d99642193.json'


### PR DESCRIPTION
*Submitted as a part of GCI competition*

The solution i came up with for #192 is that: `track.title = t.get('title', t['recording']['title'])`.

**Explaination**
Since if a track itself doesn't have a title then the track title is the same with the recording title. Otherwise, a track has its own title then `t['title']` is different from `t['recording']['title']` and whipper chooses `t['title']`.

Note: I also added a test case for this using an existing [release JSON file](https://github.com/whipper-team/whipper/blob/develop/whipper/test/whipper.release.c56ff16e-1d81-47de-926f-ba22891bd2bd.json).