### PR TITLE
Allow whipper's mblookup command to look up information based on Release MBID

### DIFF
--- a/whipper/command/mblookup.py
+++ b/whipper/command/mblookup.py
@@ -1,5 +1,7 @@
 from whipper.command.basecommand import BaseCommand
-from whipper.common.mbngs import musicbrainz
+from whipper.common.mbngs import musicbrainz, getReleaseMetadata
+
+import re
 
 
 class MBLookup(BaseCommand):
@@ -12,35 +14,58 @@ Example disc id: KnpGsLhvH.lPrNc1PBL21lb9Bg4-"""
 
     def add_arguments(self):
         self.parser.add_argument(
-            'mbdiscid', action='store', help="MB disc id to look up"
+            'mbid', action='store', help="MB disc id or release id to look up"
         )
+
+    def _printMetadata(self, md):
+        """
+        Print out metadata received in a sensible way.
+
+        :param md: MusicBrainz's metadata about the disc
+        :type md: `DiscMetadata`
+        """
+        print('    Artist: %s' % md.artist.encode('utf-8'))
+        print('    Title:  %s' % md.title.encode('utf-8'))
+        print('    Type:   %s' % str(md.releaseType).encode('utf-8'))
+        print('    URL:    %s' % md.url)
+        print('    Tracks: %d' % len(md.tracks))
+        if md.catalogNumber:
+            print('    Cat no: %s' % md.catalogNumber)
+        if md.barcode:
+            print('    Barcode: %s' % md.barcode)
+
+            for j, track in enumerate(md.tracks):
+                print('      Track %2d: %s - %s' % (
+                    j + 1, track.artist.encode('utf-8'),
+                    track.title.encode('utf-8')
+                ))
 
     def do(self):
         try:
-            discId = str(self.options.mbdiscid)
+            mbid = str(self.options.mbid.strip())
         except IndexError:
-            print('Please specify a MusicBrainz disc id.')
+            print('Please specify a MusicBrainz disc id or release id.')
             return 3
 
-        metadatas = musicbrainz(discId)
+        releaseIdMatch = re.match(
+            r'^[\dA-Fa-f]{8}-(?:[\dA-Fa-f]{4}-){3}[\dA-Fa-f]{12}$',
+            mbid
+        )
+        discIdMatch = re.match(
+            r'^[\dA-Za-z._]{27}-$',
+            mbid
+        )
 
-        print('%d releases' % len(metadatas))
-        for i, md in enumerate(metadatas):
-            print('- Release %d:' % (i + 1, ))
-            print('    Artist: %s' % md.artist.encode('utf-8'))
-            print('    Title:  %s' % md.title.encode('utf-8'))
-            print('    Type:   %s' % str(md.releaseType).encode('utf-8'))  # noqa: E501
-            print('    URL:    %s' % md.url)
-            print('    Tracks: %d' % len(md.tracks))
-            if md.catalogNumber:
-                print('    Cat no: %s' % md.catalogNumber)
-            if md.barcode:
-                print('    Barcode: %s' % md.barcode)
+        # see https://musicbrainz.org/doc/MusicBrainz_Identifier
+        if releaseIdMatch:
+            md = getReleaseMetadata(releaseIdMatch.group(0))
+            if md:
+                self._printMetadata(md)
+        elif discIdMatch:
+            metadatas = musicbrainz(discIdMatch.group(0))
 
-                for j, track in enumerate(md.tracks):
-                    print('      Track %2d: %s - %s' % (
-                        j + 1, track.artist.encode('utf-8'),
-                        track.title.encode('utf-8')
-                    ))
-
+            print('%d releases' % len(metadatas))
+            for i, md in enumerate(metadatas):
+                print('- Release %d:' % (i + 1, ))
+                self._printMetadata(md)
         return None


### PR DESCRIPTION
*Submitted as a part of GCI competition*

Solution for #251 is that adding ability to detect release id or disc id with RegExp to `mblookup` command and get metadata of a release by a new method `getReleaseMetadata` in `common/mbngs` then print it out in a sensible way.

**`mblookup` new usage**

`whipper mblookup discid/releaseid` to look up data based on release id or disc id.

*I have also added a test case for this.*