### PR TITLE
Test against Python versions 3.6, 3.7, and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: required
 language: python
 python:
   - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
 virtualenv:
   system_site_packages: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,11 @@ cache: pip
 
 env:
     - FLAKE8=false
-    - FLAKE8=true
+
+jobs:
+  include:
+  - python: 3.5
+    env: FLAKE8=true
 
 install:
     # Dependencies


### PR DESCRIPTION
Right now tests are only run against Python 3.5, but we claim we support Python 3.5+ so let’s run our tests against both Python 3.5 and all later (stable) versions.