### PR TITLE
Fix whipper's MusicBrainz Disc ID calculation for CDs with data tracks that are not positioned at the end of the disc 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
     # Dependencies
     - sudo apt-get -qq update
     - pip install --upgrade -qq pip
-    - sudo apt-get -qq install cdparanoia cdrdao flac gir1.2-glib-2.0 libcdio-dev libgirepository1.0-dev libiso9660-dev libsndfile1-dev sox swig libcdio-utils
+    - sudo apt-get -qq install cdparanoia cdrdao flac gir1.2-glib-2.0 libcdio-dev libgirepository1.0-dev libiso9660-dev libsndfile1-dev sox swig libcdio-utils libdiscid0
     # newer version of pydcio requires newer version of libcdio than travis has
     - pip install pycdio==0.21
     # install rest of dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     flac \
     gir1.2-glib-2.0 \
     git \
+    libdiscid0 \
     libiso9660-dev \
     libsndfile1-dev \
     libtool \
@@ -27,7 +28,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     sox \
     swig \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
-    && pip3 --no-cache-dir install pycdio==2.1.0
+    && pip3 --no-cache-dir install pycdio==2.1.0 discid
 
 # libcdio-paranoia / libcdio-utils are wrongfully packaged in Debian, thus built manually
 # see https://github.com/whipper-team/whipper/pull/237#issuecomment-367985625

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Whipper relies on the following packages in order to run correctly and provide a
 - [setuptools](https://pypi.python.org/pypi/setuptools), for installation, plugins support
 - [requests](https://pypi.python.org/pypi/requests), for retrieving AccurateRip database entries
 - [pycdio](https://pypi.python.org/pypi/pycdio/), for drive identification (required for drive offset and caching behavior to be stored in the configuration file).
+- [discid](https://pypi.org/project/discid/), for calculating Musicbrainz disc id.
   - To avoid bugs it's advised to use the most recent `pycdio` version with the corresponding `libcdio` release or, if stuck to old pycdio versions, **0.20**/**0.21** with `libcdio` ≥ **0.90** ≤ **0.94**. All other combinations won't probably work.
 - [ruamel.yaml](https://pypi.org/project/ruamel.yaml/), for generating well formed YAML report logfiles
 - [libsndfile](http://www.mega-nerd.com/libsndfile/), for reading wav files
@@ -148,6 +149,7 @@ Some dependencies aren't available in the PyPI. They can be probably installed u
 - [flac](https://xiph.org/flac/)
 - [sox](http://sox.sourceforge.net/)
 - [git](https://git-scm.com/) or [mercurial](https://www.mercurial-scm.org/)
+- [libdiscid](https://musicbrainz.org/doc/libdiscid)
 
 PyPI installable dependencies are listed in the [requirements.txt](https://github.com/whipper-team/whipper/blob/master/requirements.txt) file and can be installed issuing the following command:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ PyGObject
 requests
 ruamel.yaml
 setuptools_scm
+discid

--- a/whipper/test/test_image_toc.py
+++ b/whipper/test/test_image_toc.py
@@ -271,6 +271,13 @@ class CapitalMergeTestCase(common.TestCase):
         self.assertEqual(self.table.getFrameLength(), 173530)
         self.assertEqual(self.table.duration(), 2313733)
 
+    def testMusicBrainzDataTrackFirst(self):
+        self.table = copy.deepcopy(self.toc2.table)
+        self.table.merge(self.toc1.table)
+        print(self.table.tracks)
+        self.assertEqual(self.table.getMusicBrainzDiscId(),
+                         "QTYYFFAgNK4Np2EHjfPTBavqtw8-")
+
 
 class UnicodeTestCase(common.TestCase, common.UnicodeTestMixin):
 


### PR DESCRIPTION
*Submitted as a part of GCI competition*

**Description**
Fixes: #289.

"Throwing out the custom calculation code from morituri in favour of [libdiscid](https://python-discid.readthedocs.io/en/latest/)."

This pull request gives a new way to calculate disc `leadout` or `sectors` (the end of last audio track) depends on whether the data track is placed last or not. 

If the data track is at the end then subtract from the beginning of data track like whipper initially did.
If not, the `additional` variable is increased by 1 (can be accumulative) then `sectors` is the end of the actual last audio track number which is `lastTrack + additional`.

**Problem**
The test case is not verified.

 [python-discid](https://github.com/JonnyJD/python-discid/blob/e5c2a6c77e4d5b7d527c465b8dc37015b4da743d/discid/disc.py#L164) requires `len(track_offsets) != last - first + 1` with `first` is always 1 and `len(track_offsets)` is always number of audio tracks. Which means the `lastTrack` number is deceptive since it always equals to number of audio tracks but it is described as `last **audio** track as :obj:int` [here](https://github.com/JonnyJD/python-discid/blob/9a5993c1a4d5b7db4366d999a1fd3c9eaa672e29/discid/disc.py#L62).

For example: a disc (data audio audio audio) has `firstTrack=1` `lastTrack=3` which is wrong since 
it should be 4.

Discs with data tracks both at the end and not at the end of `tracks` or 
Discs with multiple consecutive data tracks at the end **are not taken into account yet**.