### PR TITLE
Fix cover file saving with /tmp on different FS

### DIFF
--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -25,6 +25,7 @@ Common functionality and class for all programs using whipper.
 import musicbrainzngs
 import re
 import os
+import shutil
 import time
 
 from tempfile import NamedTemporaryFile
@@ -495,7 +496,7 @@ class Program:
             with NamedTemporaryFile(suffix='.cover.jpg', delete=False) as f:
                 f.write(data)
             os.chmod(f.name, 0o644)
-            os.replace(f.name, cover_art_path)
+            shutil.move(f.name, cover_art_path)
             logger.debug('cover art fetched at: %r', cover_art_path)
             return cover_art_path
         return


### PR DESCRIPTION
If the directory used by `tempfile.NamedTemporaryFile` is on a different filesystem (e.g. `/tmp` on `tmpfs`), `whipper cd rip --cover-art` will fail with an error such as:

    Traceback (most recent call last):
      File "/usr/bin/whipper", line 11, in <module>
        load_entry_point('whipper==0.9.0', 'console_scripts', 'whipper')()
      File "/home/kevin/tmp/whipper/whipper/command/main.py", line 43, in main
        ret = cmd.do()
      File "/home/kevin/tmp/whipper/whipper/command/basecommand.py", line 139, in do
        return self.cmd.do()
      File "/home/kevin/tmp/whipper/whipper/command/basecommand.py", line 139, in do
        return self.cmd.do()
      File "/home/kevin/tmp/whipper/whipper/command/cd.py", line 191, in do
        self.doCommand()
      File "/home/kevin/tmp/whipper/whipper/command/cd.py", line 363, in doCommand
        self.program.metadata.mbid)
      File "/home/kevin/tmp/whipper/whipper/common/program.py", line 498, in getCoverArt
        os.replace(f.name, cover_art_path)
    OSError: [Errno 18] Invalid cross-device link: '/tmp/tmprmx4d9c9.cover.jpg' -> './Boston/Greatest Hits/cover.jpg'

due to calling `os.replace` with paths on different filesystems.

Instead of `os.replace`, this PR uses `shutil.move`, which falls back to `shutil.copy2` if `os.replace` doesn't work.

Thanks for considering,
Kevin