### PR TITLE
Fix crash fetching cover art for unknown album

### DIFF
--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -358,9 +358,14 @@ Log files will log the path to tracks relative to this directory.
                            "because the 'pillow' module isn't available",
                            self.options.fetch_cover_art)
         elif self.options.fetch_cover_art in {"file", "embed", "complete"}:
-            self.coverArtPath = self.program.getCoverArt(
-                                    dirname,
-                                    self.program.metadata.mbid)
+            if getattr(self.program.metadata, "mbid", None) is not None:
+                self.coverArtPath = self.program.getCoverArt(
+                                        dirname,
+                                        self.program.metadata.mbid)
+            else:
+                logger.warning("the cover art option '%s' won't be honored "
+                               "because disc metadata isn't available",
+                               self.options.fetch_cover_art)
         if self.options.fetch_cover_art == "file":
             self.coverArtPath = None  # NOTE: avoid image embedding (hacky)
 


### PR DESCRIPTION
Ripping an unknown album when cover art fetching is enabled (e.g. `whipper cd rip --unknown --cover-art complete`) causes whipper to crash with an error similar to the following:

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File ".../whipper/whipper/command/main.py", line 43, in main
        ret = cmd.do()
      File ".../whipper/whipper/command/basecommand.py", line 139, in do
        return self.cmd.do()
      File ".../whipper/whipper/command/basecommand.py", line 139, in do
        return self.cmd.do()
      File ".../whipper/whipper/command/cd.py", line 191, in do
        self.doCommand()
      File ".../whipper/whipper/command/cd.py", line 363, in doCommand
        self.program.metadata.mbid)
    AttributeError: 'NoneType' object has no attribute 'mbid'

due to accessing `self.program.metadata.mbid` when `self.program.metadata` is `None`.  This PR attempts to avoid teh issue by only fetching cover art when `self.program.metadata` is available.

Thanks for considering,
Kevin