### PR TITLE
Fix cd rip --max-retries option handling

### DIFF
--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -299,7 +299,7 @@ Log files will log the path to tracks relative to this directory.
                                  "complete option values respectively",
                                  choices=['file', 'embed', 'complete'],
                                  default=None)
-        self.parser.add_argument('r', '--max-retries',
+        self.parser.add_argument('-r', '--max-retries',
                                  action="store", dest="max_retries",
                                  help="number of rip attempts before giving "
                                  "up if can't rip a track. This defaults to "


### PR DESCRIPTION
9db3aa9 introduced the -r/--max-retries option, but passed `'r'` to `argparse.ArgumentParser.add_argument` instead of `'-r'` which causes:

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File ".../whipper/command/main.py", line 48, in main
        cmd = Whipper(sys.argv[1:], os.path.basename(sys.argv[0]), None)
      File ".../whipper/command/basecommand.py", line 117, in __init__
        self.options
      File ".../whipper/command/basecommand.py", line 117, in __init__
        self.options
      File ".../whipper/command/basecommand.py", line 60, in __init__
        self.add_arguments()
      File ".../whipper/command/cd.py", line 308, in add_arguments
        default=DEFAULT_MAX_RETRIES)
      File "/usr/lib/python3.7/argparse.py", line 1354, in add_argument
        kwargs = self._get_optional_kwargs(*args, **kwargs)
      File "/usr/lib/python3.7/argparse.py", line 1485, in _get_optional_kwargs
        raise ValueError(msg % args)
    ValueError: invalid option string 'r': must start with a character '-'

for any arguments passed to `whipper cd rip`.  This PR fixes it.

Thanks for considering,
Kevin