### PR TITLE
Restore the ability to use inline comments in config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,13 +229,13 @@ The configuration file is stored in `$XDG_CONFIG_HOME/whipper/whipper.conf`, or 
 
 See [XDG Base Directory
 Specification](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html)
-and [ConfigParser](https://docs.python.org/3/library/configparser.html).
+and [ConfigParser](https://docs.python.org/3/library/configparser.html) with `inline_comment_prefixes=(';')`.
 
 The configuration file consists of newline-delineated `[sections]`
 containing `key = value` pairs. The sections `[main]` and
 `[musicbrainz]` are special config sections for options not accessible
 from the command line interface.  Sections beginning with `drive` are
-written by whipper; certain values should not be edited.
+written by whipper; certain values should not be edited. Inline comments can be added using `;`.
 
 Example configuration demonstrating all `[main]` and `[musicbrainz]`
 options:

--- a/whipper/common/config.py
+++ b/whipper/common/config.py
@@ -36,7 +36,8 @@ class Config:
     def __init__(self, path=None):
         self._path = path or directory.config_path()
 
-        self._parser = configparser.ConfigParser()
+        self._parser = configparser.ConfigParser(
+            inline_comment_prefixes=(';'))
 
         self.open()
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whipper-team/whipper/461)
<!-- Reviewable:end -->
