### PR TITLE
WIP: Add more metadata options for file templates

### DIFF
--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -54,6 +54,10 @@ filling in the variables and adding the file extension. Variables for both
 disc and track template are:
  - %A: release artist
  - %S: release sort name
+ - %D: release title
+ - %T: medium title
+ - %N: medium position
+ - %M: medium count
  - %d: disc title
  - %y: release year
  - %r: release type, lowercase

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -295,6 +295,11 @@ Log files will log the path to tracks relative to this directory.
                                  help="whether to continue ripping if "
                                  "the disc is a CD-R",
                                  default=False)
+        self.parser.add_argument('--on-log-found',
+                                 action="store", dest="log_found",
+                                 help="what to do if a log file already exists",
+                                 choices=['stop', 'ask', 'continue'],
+                                 default='stop')
         self.parser.add_argument('-C', '--cover-art',
                                  action="store", dest="cover_art",
                                  help="fetch cover art and save it as "
@@ -366,7 +371,15 @@ Log files will log the path to tracks relative to this directory.
             if logs:
                 msg = ("output directory %s is a finished rip" % dirname)
                 logger.debug(msg)
-                raise RuntimeError(msg)
+                if self.options.log_found == 'stop':
+                    raise RuntimeError(msg)
+                else:
+                    print("Found log files in %s, this may be a finished rip"
+                          % dirname)
+                    print(logs)
+                    if self.options.log_found == 'ask':
+                        if input('Continue anyway? [y/n] ').lower() != 'y':
+                            raise RuntimeError(msg)
         else:
             logger.info("creating output directory %s", dirname)
             os.makedirs(dirname)

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -130,6 +130,9 @@ class _CD(BaseCommand):
                 logger.critical("unable to retrieve disc metadata, "
                                 "--unknown argument not passed")
                 return -1
+        elif self.program.metadata.mediumCount != '1':
+            self.options.track_template = self.options.track_template_mdisc
+            self.options.disc_template = self.options.disc_template_mdisc
 
         self.program.result.isCdr = cdrdao.DetectCdr(self.device)
         if (self.program.result.isCdr and
@@ -282,10 +285,18 @@ Log files will log the path to tracks relative to this directory.
                                  action="store", dest="track_template",
                                  default=DEFAULT_TRACK_TEMPLATE,
                                  help="template for track file naming")
+        self.parser.add_argument('--track-template-mdisc',
+                                 action="store", dest="track_template_mdisc",
+                                 help="template for track file naming "
+                                 "for a multidisc collection")
         self.parser.add_argument('--disc-template',
                                  action="store", dest="disc_template",
                                  default=DEFAULT_DISC_TEMPLATE,
                                  help="template for disc file naming")
+        self.parser.add_argument('--disc-template-mdisc',
+                                 action="store", dest="disc_template_mdisc",
+                                 help="template for disc file naming "
+                                 "for a multidisc collection")
         self.parser.add_argument('-U', '--unknown',
                                  action="store_true", dest="unknown",
                                  help="whether to continue ripping if "
@@ -322,8 +333,16 @@ Log files will log the path to tracks relative to this directory.
 
         self.options.track_template = self.options.track_template
         validate_template(self.options.track_template, 'track')
+        if self.options.track_template_mdisc:
+            validate_template(self.options.track_template_mdisc, 'track')
+        else:
+            self.options.track_template_mdisc = self.options.track_template
         self.options.disc_template = self.options.disc_template
         validate_template(self.options.disc_template, 'disc')
+        if self.options.disc_template_mdisc:
+            validate_template(self.options.disc_template_mdisc, 'disc')
+        else:
+            self.options.disc_template_mdisc = self.options.disc_template
 
         if self.options.offset is None:
             raise ValueError("Drive offset is unconfigured.\n"

--- a/whipper/common/common.py
+++ b/whipper/common/common.py
@@ -277,9 +277,9 @@ def getRelativePath(targetPath, collectionPath):
 def validate_template(template, kind):
     """Raise exception if disc/track template includes invalid variables."""
     if kind == 'disc':
-        matches = re.findall(r'%[^ARSXdrxy]', template)
+        matches = re.findall(r'%[^ADMNRSTXdrxy]', template)
     elif kind == 'track':
-        matches = re.findall(r'%[^ARSXadnrstxy]', template)
+        matches = re.findall(r'%[^ADMNRSTXadnrstxy]', template)
     if '%' in template and matches:
         raise ValueError(kind + ' template string contains invalid '
                          'variable(s): {}'.format(', '.join(matches)))

--- a/whipper/common/mbngs.py
+++ b/whipper/common/mbngs.py
@@ -92,6 +92,9 @@ class DiscMetadata:
     barcode = None
     countries = None
 
+    mediumPosition = None
+    mediumCount = None
+
     def __init__(self):
         self.tracks = []
 
@@ -289,6 +292,11 @@ def _getMetadata(release, discid=None, country=None):
                 if count > 1:
                     title += ' (Disc %d of %d)' % (
                         int(medium['position']), count)
+                discMD.mediumCount = str(count)
+                if 'position' in medium:
+                    discMD.mediumPosition = medium['position']
+                else:
+                    discMD.mediumPosition = '1'
                 if 'title' in medium:
                     title += ": %s" % medium['title']
                 discMD.title = title

--- a/whipper/common/mbngs.py
+++ b/whipper/common/mbngs.py
@@ -94,6 +94,7 @@ class DiscMetadata:
 
     mediumPosition = None
     mediumCount = None
+    mediumTitle = None
 
     def __init__(self):
         self.tracks = []
@@ -298,6 +299,7 @@ def _getMetadata(release, discid=None, country=None):
                 else:
                     discMD.mediumPosition = '1'
                 if 'title' in medium:
+                    discMD.mediumTitle = medium['title']
                     title += ": %s" % medium['title']
                 discMD.title = title
                 for t in medium['track-list']:

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -201,6 +201,10 @@ class Program:
 
         * ``%A``: release artist
         * ``%S``: release artist sort name
+        * ``%D``: release title
+        * ``%T``: medium title
+        * ``%N``: medium positon
+        * ``%M``: medium count
         * ``%d``: disc title
         * ``%y``: release year
         * ``%r``: release type, lowercase
@@ -217,6 +221,8 @@ class Program:
         v['R'] = 'Unknown'
         v['B'] = ''  # barcode
         v['C'] = ''  # catalog number
+        v['N'] = '1'
+        v['M'] = '1'
         v['x'] = 'flac'
         v['X'] = v['x'].upper()
         v['y'] = '0000'
@@ -234,8 +240,13 @@ class Program:
             v['A'] = self._filter.filter(metadata.artist)
             v['S'] = self._filter.filter(metadata.sortName)
             v['d'] = self._filter.filter(metadata.title)
+            v['D'] = self._filter.filter(metadata.releaseTitle)
+            if metadata.mediumTitle:
+                v['T'] = self._filter.filter(metadata.mediumTitle)
             v['B'] = metadata.barcode
             v['C'] = metadata.catalogNumber
+            v['M'] = metadata.mediumCount
+            v['N'] = metadata.mediumPosition
             if metadata.releaseType:
                 v['R'] = metadata.releaseType
                 v['r'] = metadata.releaseType.lower()
@@ -249,6 +260,13 @@ class Program:
             elif track_number == 0:
                 # htoa defaults to disc's artist
                 v['a'] = self._filter.filter(metadata.artist)
+
+        if 'S' not in v:
+            v['S'] = v['A']
+        if 'D' not in v:
+            v['D'] = v['d']
+        if 'T' not in v:
+            v['T'] = '%0*d' % (len(v['M']), int(v['N']))
 
         template = re.sub(r'%(\w)', r'%(\1)s', template)
         return os.path.join(outdir, template % v)

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -488,6 +488,13 @@ class Program:
             if self.metadata.release is not None:
                 tags['DATE'] = self.metadata.release
 
+            if self.metadata.mediumCount:
+                tags['DISCNUMBER'] = self.metadata.mediumPosition
+                tags['DISCTOTAL'] = self.metadata.mediumCount
+
+            if self.metadata.tracks:
+                tags['TRACKTOTAL'] = str(len(self.metadata.tracks))
+
             if number > 0:
                 tags['MUSICBRAINZ_RELEASETRACKID'] = mbidTrack
                 tags['MUSICBRAINZ_TRACKID'] = mbidRecording


### PR DESCRIPTION
Notice this probably shouldn't be merged as is, I've just copied and adapted some other code already in whipper, not really knowing if what I was doing was right.    I've not even run the tests, or updated them and the documentation.

The WIP tag means it works for me (a very light user) and someone with real knowledge can take it and do it The Right Way, not that I'm still working on it.

May be of use to #448, #440 and #401. Given that the 'bare' release title is provided through a new variable, it doesn't affect users that like current behaviour. The flac metadata is still in the long format, though. The new ...-mdisc options may be too much, but they also may be useful if you launch whipper from a script and you want different templates for mono- and multi-disc releases.

Feel free to appropriate the good bits, discard the garbage, open a new PR and close this one.