### PR TITLE
Define libcdio version as environment variables in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,22 +32,24 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 # libcdio-paranoia / libcdio-utils are wrongfully packaged in Debian, thus built manually
 # see https://github.com/whipper-team/whipper/pull/237#issuecomment-367985625
-RUN curl -o - 'https://ftp.gnu.org/gnu/libcdio/libcdio-2.1.0.tar.bz2' | tar jxf - \
-    && cd libcdio-2.1.0 \
+ENV LIBCDIO_VERSION 2.1.0
+RUN curl -o - "https://ftp.gnu.org/gnu/libcdio/libcdio-${LIBCDIO_VERSION}.tar.bz2" | tar jxf - \
+    && cd libcdio-${LIBCDIO_VERSION} \
     && autoreconf -fi \
     && ./configure --disable-dependency-tracking --disable-cxx --disable-example-progs --disable-static \
     && make install \
     && cd .. \
-    && rm -rf libcdio-2.1.0
+    && rm -rf libcdio-${LIBCDIO_VERSION}
 
 # Install cd-paranoia from tarball
-RUN curl -o - 'https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-10.2+2.0.1.tar.bz2' | tar jxf - \
-    && cd libcdio-paranoia-10.2+2.0.1 \
+ENV LIBCDIO_PARANOIA_VERSION 10.2+2.0.1
+RUN curl -o - "https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-${LIBCDIO_PARANOIA_VERSION}.tar.bz2" | tar jxf - \
+    && cd libcdio-paranoia-${LIBCDIO_PARANOIA_VERSION} \
     && autoreconf -fi \
     && ./configure --disable-dependency-tracking --disable-example-progs --disable-static \
     && make install \
     && cd .. \
-    && rm -rf libcdio-paranoia-10.2+2.0.1
+    && rm -rf libcdio-paranoia-${LIBCDIO_PARANOIA_VERSION}
 
 RUN ldconfig
 


### PR DESCRIPTION
This moves the version for libcdio and libcdio-paranoia to be environment variables (defined above where they're used) and then uses that variable where the version is needed. This makes it a bit easier to update the version, having only to update one line instead of 3 (x2). This was inspired looking at the commit history for the last time libcdio-paranoia version.

Signed-off-by: Matthew Peveler <matt.peveler@gmail.com>