### PR TITLE
Fix capitalization of "Health status" in rip log

### DIFF
--- a/whipper/result/logger.py
+++ b/whipper/result/logger.py
@@ -141,7 +141,7 @@ class WhipperLogger(result.Logger):
             message = "There were errors"
         else:
             message = "No errors occurred"
-        data["Health Status"] = message
+        data["Health status"] = message
         data["EOF"] = "End of status report"
         riplog["Conclusive status report"] = data
 

--- a/whipper/test/test_result_logger.log
+++ b/whipper/test/test_result_logger.log
@@ -74,7 +74,7 @@ Tracks:
 
 Conclusive status report:
   AccurateRip summary: All tracks accurately ripped
-  Health Status: No errors occurred
+  Health status: No errors occurred
   EOF: End of status report
 
 SHA-256 hash: 2B176D8C722989B25459160E335E5CC0C1A6813C9DA69F869B625FBF737C475E


### PR DESCRIPTION
This fixes a regression from move to ruamel.yaml where all other fields in rip log have second word lowercased, except for "Health Status". This changes it to make it inline with all other fields again.

Signed-off-by: Matthew Peveler <matt.peveler@gmail.com>