### PR TITLE
Parameterise the UID of the worker user in the docker build file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
+ARG uid=1000
 FROM debian:buster
 ARG optical_gid
+ARG uid
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     autoconf \
@@ -55,7 +57,7 @@ RUN curl -o - "https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-${LIBCDIO_PARANO
 RUN ldconfig
 
 # add user (+ group workaround for ArchLinux)
-RUN useradd -m worker -G cdrom \
+RUN useradd -m worker --uid ${uid} -G cdrom \
     && if [ -n "${optical_gid}" ]; then groupadd -f -g "${optical_gid}" optical \
     && usermod -a -G optical worker; fi \
     && mkdir -p /output /home/worker/.config/whipper \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-ARG uid=1000
 FROM debian:buster
 ARG optical_gid
-ARG uid
+ARG uid=1000
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     autoconf \

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Building the Docker image locally is required in order to make it work on Arch L
 
 To build the Docker image locally just issue the following command (it relies on the [Dockerfile](https://github.com/whipper-team/whipper/blob/develop/Dockerfile) included in whipper's repository):
 
-`optical_gid=$(getent group optical | cut -d: -f3) docker build --build-arg optical_gid -t whipperteam/whipper .`
+`optical_gid=$(getent group optical | cut -d: -f3) uid=$(id -u) docker build --build-arg optical_gid --build-arg uid -t whipperteam/whipper .`
 
 It's recommended to create an alias for a convenient usage:
 


### PR DESCRIPTION
All small change that allows users whose UID is not 1000 to build and use the Dockerfile. 

If no UID is supplied as a build argument then the build continues as before. 

The documentation has also been updated to reflect the new build argument.