### PR TITLE
Added --keep-going option to cd rip command

### DIFF
--- a/man/whipper-cd-rip.rst
+++ b/man/whipper-cd-rip.rst
@@ -69,6 +69,10 @@ Options
 |     Number of rip attempts before giving up if can't rip a track. This
 |     defaults to 5; 0 means infinity.
 
+| **-k** | **--keep-going**
+|     continue ripping further tracks instead of giving up if a track can't be
+|     ripped
+
 Template schemes
 ================
 

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -192,13 +192,13 @@ class _CD(BaseCommand):
             cdio.Device(self.device).get_hwinfo()
         self.program.result.metadata = self.program.metadata
 
-        self.doCommand()
+        ret = self.doCommand()
 
         if (self.options.eject == 'success' and self.eject or
                 self.options.eject == 'always'):
             utils.eject_device(self.device)
 
-        return None
+        return ret
 
     def doCommand(self):
         pass
@@ -490,7 +490,8 @@ Log files will log the path to tracks relative to this directory.
                         logger.debug("adding %s to skipped_tracks"
                                      % trackResult.filename)
                         self.skipped_tracks.append(trackResult.filename)
-                        logger.debug(f"skipped_tracks = {self.skipped_tracks}")
+                        logger.debug("skipped_tracks = %s"
+                                     % self.skipped_tracks)
                         trackResult.skipped = True
                         logger.debug('trackResult.skipped = True')
                     else:
@@ -531,9 +532,9 @@ Log files will log the path to tracks relative to this directory.
                                         self.itable.getTrackStart(1), number)
             else:
                 if trackResult.filename in self.skipped_tracks:
-                    logger.debug("track %d (%s) "
+                    logger.debug("track %d (%s)"
                                  "has been skipped; not adding to self.itable"
-                                 % number, trackResult.filename)
+                                 % (number, trackResult.filename))
                 else:
                     self.itable.setFile(number, 1, trackResult.filename,
                                         self.itable.getTrackLength(number),
@@ -580,6 +581,12 @@ Log files will log the path to tracks relative to this directory.
         accurip.print_report(self.program.result)
 
         self.program.writeLog(discName, self.logger)
+
+        if len(self.skipped_tracks) > 0:
+            logger.warning('%d tracks have been skipped from this rip attempt'
+                           % len(self.skipped_tracks))
+            return 5
+        return None
 
 
 class CD(BaseCommand):

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -485,13 +485,12 @@ Log files will log the path to tracks relative to this directory.
                     logger.critical('giving up on track %d after %d times',
                                     number, tries)
                     if self.options.keep_going:
-                        logger.warning("track %d failed to rip. "
-                                       "Continuing to next track" % number)
-                        logger.debug("adding %s to skipped_tracks"
-                                     % trackResult.filename)
+                        logger.warning("track %d failed to rip.", number)
+                        logger.debug("adding %s to skipped_tracks",
+                                     trackResult.filename)
                         self.skipped_tracks.append(trackResult.filename)
-                        logger.debug("skipped_tracks = %s"
-                                     % self.skipped_tracks)
+                        logger.debug("skipped_tracks = %s",
+                                     self.skipped_tracks)
                         trackResult.skipped = True
                         logger.debug('trackResult.skipped = True')
                     else:
@@ -501,8 +500,7 @@ Log files will log the path to tracks relative to this directory.
                                            self.options.max_retries)
                 if trackResult.filename in self.skipped_tracks:
                     print("Skipping CRC comparison for track %d "
-                          "due to rip failure"
-                          % number)
+                          "due to rip failure" % number)
                 else:
                     if trackResult.testcrc == trackResult.copycrc:
                         logger.info('CRCs match for track %d', number)
@@ -532,9 +530,9 @@ Log files will log the path to tracks relative to this directory.
                                         self.itable.getTrackStart(1), number)
             else:
                 if trackResult.filename in self.skipped_tracks:
-                    logger.debug("track %d (%s)"
-                                 "has been skipped; not adding to self.itable"
-                                 % (number, trackResult.filename))
+                    logger.debug("track %d (%s) has been skipped; "
+                                 "not adding to self.itable",
+                                 number, trackResult.filename)
                 else:
                     self.itable.setFile(number, 1, trackResult.filename,
                                         self.itable.getTrackLength(number),
@@ -583,10 +581,9 @@ Log files will log the path to tracks relative to this directory.
         self.program.writeLog(discName, self.logger)
 
         if len(self.skipped_tracks) > 0:
-            logger.warning('%d tracks have been skipped from this rip attempt'
-                           % len(self.skipped_tracks))
+            logger.warning('%d tracks have been skipped from this rip attempt',
+                           len(self.skipped_tracks))
             return 5
-        return None
 
 
 class CD(BaseCommand):

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -487,18 +487,17 @@ Log files will log the path to tracks relative to this directory.
                     if self.options.keep_going:
                         logger.warning("track %d failed to rip.", number)
                         logger.debug("adding %s to skipped_tracks",
-                                     trackResult.filename)
-                        self.skipped_tracks.append(trackResult.filename)
+                                     trackResult)
+                        self.skipped_tracks.append(trackResult)
                         logger.debug("skipped_tracks = %s",
                                      self.skipped_tracks)
                         trackResult.skipped = True
-                        logger.debug('trackResult.skipped = True')
                     else:
                         raise RuntimeError("track can't be ripped. "
                                            "Rip attempts number is equal "
                                            "to %d",
                                            self.options.max_retries)
-                if trackResult.filename in self.skipped_tracks:
+                if trackResult in self.skipped_tracks:
                     print("Skipping CRC comparison for track %d "
                           "due to rip failure" % number)
                 else:
@@ -529,14 +528,9 @@ Log files will log the path to tracks relative to this directory.
                     self.itable.setFile(1, 0, trackResult.filename,
                                         self.itable.getTrackStart(1), number)
             else:
-                if trackResult.filename in self.skipped_tracks:
-                    logger.debug("track %d (%s) has been skipped; "
-                                 "not adding to self.itable",
-                                 number, trackResult.filename)
-                else:
-                    self.itable.setFile(number, 1, trackResult.filename,
-                                        self.itable.getTrackLength(number),
-                                        number)
+                self.itable.setFile(number, 1, trackResult.filename,
+                                    self.itable.getTrackLength(number),
+                                    number)
 
         # check for hidden track one audio
         htoa = self.program.getHTOA()
@@ -570,6 +564,9 @@ Log files will log the path to tracks relative to this directory.
 
         logger.debug('writing m3u file for %r', discName)
         self.program.write_m3u(discName)
+
+        if len(self.skipped_tracks) > 0:
+            self.program.skipped_tracks = self.skipped_tracks
 
         try:
             self.program.verifyImage(self.runner, self.itable)

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -566,6 +566,9 @@ Log files will log the path to tracks relative to this directory.
         self.program.write_m3u(discName)
 
         if len(self.skipped_tracks) > 0:
+            logger.warning("the generated cue sheet references %d track(s) "
+                           "which failed to rip so the associated file(s) "
+                           "won't be available", len(self.skipped_tracks))
             self.program.skipped_tracks = self.skipped_tracks
 
         try:

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -310,6 +310,11 @@ Log files will log the path to tracks relative to this directory.
                                  "{}; 0 means "
                                  "infinity.".format(DEFAULT_MAX_RETRIES),
                                  default=DEFAULT_MAX_RETRIES)
+        self.parser.add_argument('-k', '--keep-going',
+                                 action='store_true',
+                                 help="continue ripping further tracks "
+                                 "instead of giving up if a track "
+                                 "can't be ripped")
 
     def handle_arguments(self):
         self.options.output_directory = os.path.expanduser(
@@ -476,9 +481,14 @@ Log files will log the path to tracks relative to this directory.
                     tries -= 1
                     logger.critical('giving up on track %d after %d times',
                                     number, tries)
-                    raise RuntimeError("track can't be ripped. "
-                                       "Rip attempts number is equal to %d",
-                                       self.options.max_retries)
+                    if self.options.keep_going:
+                        logger.warning("track %d failed to rip. "
+                                       "Continuing to next track", number)
+                    else:
+                        raise RuntimeError("track can't be ripped. "
+                                           "Rip attempts number is equal "
+                                           "to %d",
+                                           self.options.max_retries)
                 if trackResult.testcrc == trackResult.copycrc:
                     logger.info('CRCs match for track %d', number)
                 else:

--- a/whipper/common/accurip.py
+++ b/whipper/common/accurip.py
@@ -21,6 +21,7 @@
 
 import struct
 import whipper
+import os
 from urllib.error import URLError, HTTPError
 from urllib.request import urlopen, Request
 
@@ -111,7 +112,11 @@ def calculate_checksums(track_paths):
     logger.debug('checksumming %d tracks', track_count)
     # This is done sequentially because it is very fast.
     for i, path in enumerate(track_paths):
-        v1_sum, v2_sum = accuraterip_checksum(path, i+1, track_count)
+        if os.path.exists(path):
+            v1_sum, v2_sum = accuraterip_checksum(path, i+1, track_count)
+        else:
+            logger.warning('Can\'t checksum %s; path doesn\'t exist', path)
+            v1_sum, v2_sum = None, None
         if v1_sum is None:
             logger.error('could not calculate AccurateRip v1 checksum '
                          'for track %d %r', i + 1, path)

--- a/whipper/image/image.py
+++ b/whipper/image/image.py
@@ -120,7 +120,7 @@ class ImageVerifyTask(task.MultiSeparateTask):
     description = "Checking tracks"
     lengths = None
 
-    def __init__(self, image):
+    def __init__(self, image, skipped_tracks=[]):
         task.MultiSeparateTask.__init__(self)
 
         self._image = image
@@ -147,7 +147,17 @@ class ImageVerifyTask(task.MultiSeparateTask):
             length = cue.getTrackLength(track)
 
             if length == -1:
-                path = image.getRealPath(index.path)
+                try:
+                    path = image.getRealPath(index.path)
+                except KeyError:
+                    logger.debug('Path not found; Checking '
+                                 'if %s is a skipped track', index.path)
+                    if index.path in skipped_tracks:
+                        logger.warning('Missing file %s due to skipped track',
+                                       index.path)
+                        continue
+                    else:
+                        raise
                 assert isinstance(path, str), "%r is not str" % path
                 logger.debug('schedule scan of audio length of %r', path)
                 taskk = AudioLengthTask(path)

--- a/whipper/result/logger.py
+++ b/whipper/result/logger.py
@@ -15,6 +15,7 @@ class WhipperLogger(result.Logger):
     _accuratelyRipped = 0
     _inARDatabase = 0
     _errors = False
+    _skippedTracks = False
 
     def log(self, ripResult, epoch=time.time()):
         """Return logfile as string."""
@@ -139,6 +140,8 @@ class WhipperLogger(result.Logger):
 
         if self._errors:
             message = "There were errors"
+        elif self._skippedTracks:
+            message = "Some tracks were not ripped (skipped)"
         else:
             message = "No errors occurred"
         data["Health status"] = message
@@ -242,8 +245,12 @@ class WhipperLogger(result.Logger):
                 data["Result"] = "Track not present in AccurateRip database"
             track["AccurateRip %s" % v] = data
 
+        # Check if track has been skipped
+        if trackResult.skipped:
+            track["Status"] = "Track not ripped (skipped)"
+            self._skippedTracks = True
         # Check if Test & Copy CRCs are equal
-        if trackResult.testcrc == trackResult.copycrc:
+        elif trackResult.testcrc == trackResult.copycrc:
             track["Status"] = "Copy OK"
         else:
             self._errors = True

--- a/whipper/result/result.py
+++ b/whipper/result/result.py
@@ -38,6 +38,7 @@ class TrackResult:
     copycrc = None
     AR = None
     classVersion = 3
+    skipped = False
 
     def __init__(self):
         """


### PR DESCRIPTION
Implemented the option (`-k`, `--keep-going`) to continue ripping the CD even if one track fails to rip (as @xmixahlx suggested in #128). So this command:

```
whipper cd rip --keep-going --max-retries 8 -O some/folder
```
Would try to rip a problematic track 8 times, then continue on to the next track on the CD if the track fails to rip.

Signed-off-by: blueblots <63152708+blueblots@users.noreply.github.com>