### PR TITLE
Add requested template variables

### DIFF
--- a/man/whipper-cd-rip.rst
+++ b/man/whipper-cd-rip.rst
@@ -96,7 +96,8 @@ Template schemes
 | - %S: release sort name
 | - %B: release barcode
 | - %C: release catalog number
-| - %d: disc title
+| - %d: release title (with disambiguation)
+| - %D: disc title (without disambiguation)
 | - %y: release year
 | - %r: release type, lowercase
 | - %R: release type, normal case

--- a/man/whipper-cd-rip.rst
+++ b/man/whipper-cd-rip.rst
@@ -96,6 +96,7 @@ Template schemes
 | - %S: release sort name
 | - %B: release barcode
 | - %C: release catalog number
+| - %c: release disambiguation comment
 | - %d: release title (with disambiguation)
 | - %D: disc title (without disambiguation)
 | - %I: MusicBrainz Disc ID

--- a/man/whipper-cd-rip.rst
+++ b/man/whipper-cd-rip.rst
@@ -100,6 +100,8 @@ Template schemes
 | - %d: release title (with disambiguation)
 | - %D: disc title (without disambiguation)
 | - %I: MusicBrainz Disc ID
+| - %M: total number of discs in the chosen release
+| - %N: number of current disc
 | - %T: medium title
 | - %y: release year
 | - %r: release type, lowercase

--- a/man/whipper-cd-rip.rst
+++ b/man/whipper-cd-rip.rst
@@ -98,6 +98,7 @@ Template schemes
 | - %C: release catalog number
 | - %d: release title (with disambiguation)
 | - %D: disc title (without disambiguation)
+| - %I: MusicBrainz Disc ID
 | - %y: release year
 | - %r: release type, lowercase
 | - %R: release type, normal case

--- a/man/whipper-cd-rip.rst
+++ b/man/whipper-cd-rip.rst
@@ -94,6 +94,8 @@ Template schemes
 
 | - %A: release artist
 | - %S: release sort name
+| - %B: release barcode
+| - %C: release catalog number
 | - %d: disc title
 | - %y: release year
 | - %r: release type, lowercase

--- a/man/whipper-cd-rip.rst
+++ b/man/whipper-cd-rip.rst
@@ -100,6 +100,7 @@ Template schemes
 | - %d: release title (with disambiguation)
 | - %D: disc title (without disambiguation)
 | - %I: MusicBrainz Disc ID
+| - %T: medium title
 | - %y: release year
 | - %r: release type, lowercase
 | - %R: release type, normal case

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -58,6 +58,7 @@ disc and track template are:
  - %C: release catalog number
  - %d: release title (with disambiguation)
  - %D: disc title (without disambiguation)
+ - %I: MusicBrainz Disc ID
  - %y: release year
  - %r: release type, lowercase
  - %R: release type, normal case

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -54,6 +54,8 @@ filling in the variables and adding the file extension. Variables for both
 disc and track template are:
  - %A: release artist
  - %S: release sort name
+ - %B: release barcode
+ - %C: release catalog number
  - %d: disc title
  - %y: release year
  - %r: release type, lowercase

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -56,7 +56,8 @@ disc and track template are:
  - %S: release sort name
  - %B: release barcode
  - %C: release catalog number
- - %d: disc title
+ - %d: release title (with disambiguation)
+ - %D: disc title (without disambiguation)
  - %y: release year
  - %r: release type, lowercase
  - %R: release type, normal case
@@ -187,7 +188,7 @@ class _CD(BaseCommand):
             and self.program.metadata.artist \
             or 'Unknown Artist'
         self.program.result.title = self.program.metadata \
-            and self.program.metadata.title \
+            and self.program.metadata.releaseTitle \
             or 'Unknown Title'
         _, self.program.result.vendor, self.program.result.model, \
             self.program.result.release = \

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -60,6 +60,8 @@ disc and track template are:
  - %d: release title (with disambiguation)
  - %D: disc title (without disambiguation)
  - %I: MusicBrainz Disc ID
+ - %M: total number of discs in the chosen release
+ - %N: number of current disc
  - %T: medium title
  - %y: release year
  - %r: release type, lowercase

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -60,6 +60,7 @@ disc and track template are:
  - %d: release title (with disambiguation)
  - %D: disc title (without disambiguation)
  - %I: MusicBrainz Disc ID
+ - %T: medium title
  - %y: release year
  - %r: release type, lowercase
  - %R: release type, normal case

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -56,6 +56,7 @@ disc and track template are:
  - %S: release sort name
  - %B: release barcode
  - %C: release catalog number
+ - %c: release disambiguation comment
  - %d: release title (with disambiguation)
  - %D: disc title (without disambiguation)
  - %I: MusicBrainz Disc ID

--- a/whipper/command/mblookup.py
+++ b/whipper/command/mblookup.py
@@ -26,7 +26,7 @@ Example Disc ID: KnpGsLhvH.lPrNc1PBL21lb9Bg4-"""
         :type md: `DiscMetadata`
         """
         print('    Artist: %s' % md.artist.encode('utf-8'))
-        print('    Title:  %s' % md.title.encode('utf-8'))
+        print('    Title:  %s' % md.releaseTitle.encode('utf-8'))
         print('    Type:   %s' % str(md.releaseType).encode('utf-8'))
         print('    URL:    %s' % md.url)
         print('    Tracks: %d' % len(md.tracks))

--- a/whipper/common/common.py
+++ b/whipper/common/common.py
@@ -277,9 +277,9 @@ def getRelativePath(targetPath, collectionPath):
 def validate_template(template, kind):
     """Raise exception if disc/track template includes invalid variables."""
     if kind == 'disc':
-        matches = re.findall(r'%[^ABCDIRSTXcdrxy]', template)
+        matches = re.findall(r'%[^ABCDIMNRSTXcdrxy]', template)
     elif kind == 'track':
-        matches = re.findall(r'%[^ABCDIRSTXacdnrstxy]', template)
+        matches = re.findall(r'%[^ABCDIMNRSTXacdnrstxy]', template)
     if '%' in template and matches:
         raise ValueError(kind + ' template string contains invalid '
                          'variable(s): {}'.format(', '.join(matches)))

--- a/whipper/common/common.py
+++ b/whipper/common/common.py
@@ -277,9 +277,9 @@ def getRelativePath(targetPath, collectionPath):
 def validate_template(template, kind):
     """Raise exception if disc/track template includes invalid variables."""
     if kind == 'disc':
-        matches = re.findall(r'%[^ARSXdrxy]', template)
+        matches = re.findall(r'%[^ABCRSXdrxy]', template)
     elif kind == 'track':
-        matches = re.findall(r'%[^ARSXadnrstxy]', template)
+        matches = re.findall(r'%[^ABCRSXadnrstxy]', template)
     if '%' in template and matches:
         raise ValueError(kind + ' template string contains invalid '
                          'variable(s): {}'.format(', '.join(matches)))

--- a/whipper/common/common.py
+++ b/whipper/common/common.py
@@ -277,9 +277,9 @@ def getRelativePath(targetPath, collectionPath):
 def validate_template(template, kind):
     """Raise exception if disc/track template includes invalid variables."""
     if kind == 'disc':
-        matches = re.findall(r'%[^ABCDIRSXdrxy]', template)
+        matches = re.findall(r'%[^ABCDIRSXcdrxy]', template)
     elif kind == 'track':
-        matches = re.findall(r'%[^ABCDIRSXadnrstxy]', template)
+        matches = re.findall(r'%[^ABCDIRSXacdnrstxy]', template)
     if '%' in template and matches:
         raise ValueError(kind + ' template string contains invalid '
                          'variable(s): {}'.format(', '.join(matches)))

--- a/whipper/common/common.py
+++ b/whipper/common/common.py
@@ -277,9 +277,9 @@ def getRelativePath(targetPath, collectionPath):
 def validate_template(template, kind):
     """Raise exception if disc/track template includes invalid variables."""
     if kind == 'disc':
-        matches = re.findall(r'%[^ABCDRSXdrxy]', template)
+        matches = re.findall(r'%[^ABCDIRSXdrxy]', template)
     elif kind == 'track':
-        matches = re.findall(r'%[^ABCDRSXadnrstxy]', template)
+        matches = re.findall(r'%[^ABCDIRSXadnrstxy]', template)
     if '%' in template and matches:
         raise ValueError(kind + ' template string contains invalid '
                          'variable(s): {}'.format(', '.join(matches)))

--- a/whipper/common/common.py
+++ b/whipper/common/common.py
@@ -277,9 +277,9 @@ def getRelativePath(targetPath, collectionPath):
 def validate_template(template, kind):
     """Raise exception if disc/track template includes invalid variables."""
     if kind == 'disc':
-        matches = re.findall(r'%[^ABCDIRSXcdrxy]', template)
+        matches = re.findall(r'%[^ABCDIRSTXcdrxy]', template)
     elif kind == 'track':
-        matches = re.findall(r'%[^ABCDIRSXacdnrstxy]', template)
+        matches = re.findall(r'%[^ABCDIRSTXacdnrstxy]', template)
     if '%' in template and matches:
         raise ValueError(kind + ' template string contains invalid '
                          'variable(s): {}'.format(', '.join(matches)))

--- a/whipper/common/common.py
+++ b/whipper/common/common.py
@@ -277,9 +277,9 @@ def getRelativePath(targetPath, collectionPath):
 def validate_template(template, kind):
     """Raise exception if disc/track template includes invalid variables."""
     if kind == 'disc':
-        matches = re.findall(r'%[^ABCRSXdrxy]', template)
+        matches = re.findall(r'%[^ABCDRSXdrxy]', template)
     elif kind == 'track':
-        matches = re.findall(r'%[^ABCRSXadnrstxy]', template)
+        matches = re.findall(r'%[^ABCDRSXadnrstxy]', template)
     if '%' in template and matches:
         raise ValueError(kind + ' template string contains invalid '
                          'variable(s): {}'.format(', '.join(matches)))

--- a/whipper/common/mbngs.py
+++ b/whipper/common/mbngs.py
@@ -66,8 +66,10 @@ class DiscMetadata:
     :cvar sortName: release artist sort name
     :cvar release: earliest release date, in YYYY-MM-DD
     :vartype release: str
-    :cvar title: title of the disc (with disambiguation)
-    :cvar releaseTitle: title of the release (without disambiguation)
+    :cvar title: title of the disc (without disambiguation)
+    :vartype title: str or None
+    :cvar releaseTitle: title of the release (with disambiguation)
+    :vartype releasetitle: str or None
     :vartype tracks: list of :any:`TrackMetadata`
     :cvar countries: MusicBrainz release countries
     :vartype countries: list or None
@@ -285,17 +287,17 @@ def _getMetadata(release, discid=None, country=None):
     for medium in release['medium-list']:
         for disc in medium['disc-list']:
             if discid is None or disc['id'] == discid:
-                title = release['title']
-                discMD.releaseTitle = title
+                discMD.title = release['title']
+                discMD.releaseTitle = releaseTitle = discMD.title
                 if 'disambiguation' in release:
-                    title += " (%s)" % release['disambiguation']
+                    releaseTitle += " (%s)" % release['disambiguation']
                 count = len(release['medium-list'])
                 if count > 1:
-                    title += ' (Disc %d of %d)' % (
+                    releaseTitle += ' (Disc %d of %d)' % (
                         int(medium['position']), count)
                 if 'title' in medium:
-                    title += ": %s" % medium['title']
-                discMD.title = title
+                    releaseTitle += ": %s" % medium['title']
+                discMD.releaseTitle = releaseTitle
                 for t in medium['track-list']:
                     track = TrackMetadata()
                     trackCredit = _Credit(

--- a/whipper/common/mbngs.py
+++ b/whipper/common/mbngs.py
@@ -77,6 +77,10 @@ class DiscMetadata:
     :vartype tracks: list of :any:`TrackMetadata`
     :cvar countries: MusicBrainz release countries
     :vartype countries: list or None
+    :cvar discNumber: number of current disc
+    :vartype discNumber: int or None
+    :cvar discTotal: total number of discs in the chosen release
+    :vartype discTotal: int or None
     :cvar catalogNumber: release catalog number
     :vartype catalogNumber: str or None
     :cvar barcode: release barcode
@@ -102,6 +106,8 @@ class DiscMetadata:
     catalogNumber = None
     barcode = None
     countries = None
+    discNumber = None
+    discTotal = None
     mediumTitle = None
 
     def __init__(self):
@@ -298,10 +304,11 @@ def _getMetadata(release, discid=None, country=None):
                 if 'disambiguation' in release:
                     discMD.releaseDisambCmt = release['disambiguation']
                     releaseTitle += " (%s)" % release['disambiguation']
-                count = len(release['medium-list'])
-                if count > 1:
+                discMD.discNumber = int(medium['position'])
+                discMD.discTotal = len(release['medium-list'])
+                if discMD.discTotal > 1:
                     releaseTitle += ' (Disc %d of %d)' % (
-                        int(medium['position']), count)
+                        discMD.discNumber, discMD.discTotal)
                 if 'title' in medium:
                     discMD.mediumTitle = medium['title']
                     releaseTitle += ": %s" % medium['title']

--- a/whipper/common/mbngs.py
+++ b/whipper/common/mbngs.py
@@ -70,6 +70,8 @@ class DiscMetadata:
     :vartype title: str or None
     :cvar releaseTitle: title of the release (with disambiguation)
     :vartype releasetitle: str or None
+    :cvar releaseDisambCmt: release disambiguation comment
+    :vartype releaseDisambCmt: str or None
     :vartype tracks: list of :any:`TrackMetadata`
     :cvar countries: MusicBrainz release countries
     :vartype countries: list or None
@@ -87,6 +89,7 @@ class DiscMetadata:
     release = None
 
     releaseTitle = None
+    releaseDisambCmt = None
     releaseType = None
 
     mbid = None
@@ -290,6 +293,7 @@ def _getMetadata(release, discid=None, country=None):
                 discMD.title = release['title']
                 discMD.releaseTitle = releaseTitle = discMD.title
                 if 'disambiguation' in release:
+                    discMD.releaseDisambCmt = release['disambiguation']
                     releaseTitle += " (%s)" % release['disambiguation']
                 count = len(release['medium-list'])
                 if count > 1:

--- a/whipper/common/mbngs.py
+++ b/whipper/common/mbngs.py
@@ -71,6 +71,10 @@ class DiscMetadata:
     :vartype tracks: list of :any:`TrackMetadata`
     :cvar countries: MusicBrainz release countries
     :vartype countries: list or None
+    :cvar catalogNumber: release catalog number
+    :vartype catalogNumber: str or None
+    :cvar barcode: release barcode
+    :vartype barcode: str or None
     """
 
     artist = None

--- a/whipper/common/mbngs.py
+++ b/whipper/common/mbngs.py
@@ -72,6 +72,8 @@ class DiscMetadata:
     :vartype releasetitle: str or None
     :cvar releaseDisambCmt: release disambiguation comment
     :vartype releaseDisambCmt: str or None
+    :cvar mediumTitle: title of the medium
+    :vartype mediumTitle: str or None
     :vartype tracks: list of :any:`TrackMetadata`
     :cvar countries: MusicBrainz release countries
     :vartype countries: list or None
@@ -100,6 +102,7 @@ class DiscMetadata:
     catalogNumber = None
     barcode = None
     countries = None
+    mediumTitle = None
 
     def __init__(self):
         self.tracks = []
@@ -300,6 +303,7 @@ def _getMetadata(release, discid=None, country=None):
                     releaseTitle += ' (Disc %d of %d)' % (
                         int(medium['position']), count)
                 if 'title' in medium:
+                    discMD.mediumTitle = medium['title']
                     releaseTitle += ": %s" % medium['title']
                 discMD.releaseTitle = releaseTitle
                 for t in medium['track-list']:

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -465,6 +465,12 @@ class Program:
         if self.metadata:
             if self.metadata.release is not None:
                 tags['DATE'] = self.metadata.release
+            if self.metadata.tracks:
+                tags['TRACKTOTAL'] = str(len(self.metadata.tracks))
+            if self.metadata.discTotal is not None:
+                tags['DISCTOTAL'] = str(self.metadata.discTotal)
+            if self.metadata.discNumber is not None:
+                tags['DISCNUMBER'] = str(self.metadata.discNumber)
 
             if number > 0:
                 tags['MUSICBRAINZ_RELEASETRACKID'] = mbidTrack

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -176,6 +176,8 @@ class Program:
 
         * ``%A``: release artist
         * ``%S``: release artist sort name
+        * ``%B``: release barcode
+        * ``%C``: release catalog number
         * ``%d``: disc title
         * ``%y``: release year
         * ``%r``: release type, lowercase

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -182,6 +182,7 @@ class Program:
         * ``%d``: release title (with disambiguation)
         * ``%D``: disc title (without disambiguation)
         * ``%I``: MusicBrainz Disc ID
+        * ``%T``: medium title
         * ``%y``: release year
         * ``%r``: release type, lowercase
         * ``%R``: release type, normal case
@@ -218,6 +219,7 @@ class Program:
             v['B'] = metadata.barcode
             v['C'] = metadata.catalogNumber
             v['c'] = metadata.releaseDisambCmt
+            v['T'] = metadata.mediumTitle
             if metadata.releaseType:
                 v['R'] = metadata.releaseType
                 v['r'] = metadata.releaseType.lower()

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -180,6 +180,7 @@ class Program:
         * ``%C``: release catalog number
         * ``%d``: release title (with disambiguation)
         * ``%D``: disc title (without disambiguation)
+        * ``%I``: MusicBrainz Disc ID
         * ``%y``: release year
         * ``%r``: release type, lowercase
         * ``%R``: release type, normal case
@@ -190,7 +191,7 @@ class Program:
         assert isinstance(template, str), "%r is not str" % template
         v = {}
         v['A'] = 'Unknown Artist'
-        v['d'] = v['D'] = mbdiscid  # fallback for title
+        v['I'] = v['d'] = v['D'] = mbdiscid  # fallback for title
         v['r'] = 'unknown'
         v['R'] = 'Unknown'
         v['B'] = ''  # barcode

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -178,7 +178,8 @@ class Program:
         * ``%S``: release artist sort name
         * ``%B``: release barcode
         * ``%C``: release catalog number
-        * ``%d``: disc title
+        * ``%d``: release title (with disambiguation)
+        * ``%D``: disc title (without disambiguation)
         * ``%y``: release year
         * ``%r``: release type, lowercase
         * ``%R``: release type, normal case
@@ -189,7 +190,7 @@ class Program:
         assert isinstance(template, str), "%r is not str" % template
         v = {}
         v['A'] = 'Unknown Artist'
-        v['d'] = mbdiscid  # fallback for title
+        v['d'] = v['D'] = mbdiscid  # fallback for title
         v['r'] = 'unknown'
         v['R'] = 'Unknown'
         v['B'] = ''  # barcode
@@ -210,7 +211,8 @@ class Program:
             v['y'] = release[:4]
             v['A'] = metadata.artist
             v['S'] = metadata.sortName
-            v['d'] = metadata.title
+            v['d'] = metadata.releaseTitle
+            v['D'] = metadata.title
             v['B'] = metadata.barcode
             v['C'] = metadata.catalogNumber
             if metadata.releaseType:
@@ -318,7 +320,7 @@ class Program:
 
             for metadata in metadatas:
                 print('\nArtist  : %s' % metadata.artist)
-                print('Title   : %s' % metadata.title)
+                print('Title   : %s' % metadata.releaseTitle)
                 print('Duration: %s' % common.formatTime(
                                            metadata.duration / 1000.0))
                 print('URL     : %s' % metadata.url)
@@ -358,7 +360,7 @@ class Program:
                 if len(metadatas) == 1:
                     logger.info('picked requested release id %s', release)
                     print('Artist: %s' % metadatas[0].artist)
-                    print('Title : %s' % metadatas[0].title)
+                    print('Title : %s' % metadatas[0].releaseTitle)
                 elif not metadatas:
                     logger.warning("requested release id '%s', but none of "
                                    "the found releases match", release)
@@ -370,16 +372,16 @@ class Program:
             # If we have multiple, make sure they match
             if len(metadatas) > 1:
                 artist = metadatas[0].artist
-                releaseTitle = metadatas[0].releaseTitle
+                discTitle = metadatas[0].title
                 for i, metadata in enumerate(metadatas):
                     if not artist == metadata.artist:
                         logger.warning("artist 0: %r and artist %d: %r are "
                                        "not the same", artist, i,
                                        metadata.artist)
-                    if not releaseTitle == metadata.releaseTitle:
+                    if not discTitle == metadata.title:
                         logger.warning("title 0: %r and title %d: %r are "
-                                       "not the same", releaseTitle, i,
-                                       metadata.releaseTitle)
+                                       "not the same", discTitle, i,
+                                       metadata.title)
 
                 if not release and len(list(deltas)) > 1:
                     logger.warning('picked closest match in duration. '
@@ -409,13 +411,13 @@ class Program:
         """
         trackArtist = 'Unknown Artist'
         releaseArtist = 'Unknown Artist'
-        disc = 'Unknown Disc'
+        album = 'Unknown Album'
         title = 'Unknown Track'
 
         if self.metadata:
             trackArtist = self.metadata.artist
             releaseArtist = self.metadata.artist
-            disc = self.metadata.title
+            album = self.metadata.title  # No disambiguation is proper here
             mbidRelease = self.metadata.mbid
             mbidReleaseGroup = self.metadata.mbidReleaseGroup
             mbidReleaseArtist = self.metadata.mbidArtist
@@ -447,7 +449,7 @@ class Program:
             tags['ALBUMARTIST'] = releaseArtist
         tags['ARTIST'] = trackArtist
         tags['TITLE'] = title
-        tags['ALBUM'] = disc
+        tags['ALBUM'] = album
 
         tags['TRACKNUMBER'] = '%s' % number
 

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -182,6 +182,8 @@ class Program:
         * ``%d``: release title (with disambiguation)
         * ``%D``: disc title (without disambiguation)
         * ``%I``: MusicBrainz Disc ID
+        * ``%M``: total number of discs in the chosen release
+        * ``%N``: number of current disc
         * ``%T``: medium title
         * ``%y``: release year
         * ``%r``: release type, lowercase
@@ -219,6 +221,8 @@ class Program:
             v['B'] = metadata.barcode
             v['C'] = metadata.catalogNumber
             v['c'] = metadata.releaseDisambCmt
+            v['M'] = metadata.discTotal
+            v['N'] = metadata.discNumber
             v['T'] = metadata.mediumTitle
             if metadata.releaseType:
                 v['R'] = metadata.releaseType

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -178,6 +178,7 @@ class Program:
         * ``%S``: release artist sort name
         * ``%B``: release barcode
         * ``%C``: release catalog number
+        * ``%c``: release disambiguation comment
         * ``%d``: release title (with disambiguation)
         * ``%D``: disc title (without disambiguation)
         * ``%I``: MusicBrainz Disc ID
@@ -216,6 +217,7 @@ class Program:
             v['D'] = metadata.title
             v['B'] = metadata.barcode
             v['C'] = metadata.catalogNumber
+            v['c'] = metadata.releaseDisambCmt
             if metadata.releaseType:
                 v['R'] = metadata.releaseType
                 v['r'] = metadata.releaseType.lower()

--- a/whipper/test/test_common_program.py
+++ b/whipper/test/test_common_program.py
@@ -25,7 +25,7 @@ class PathTestCase(unittest.TestCase):
         prog = program.Program(config.Config())
         md = mbngs.DiscMetadata()
         md.artist = md.sortName = 'Jeff Buckley'
-        md.title = 'Grace'
+        md.releaseTitle = 'Grace'
 
         path = prog.getPath('/tmp', DEFAULT_DISC_TEMPLATE,
                             'mbdiscid', md, 0)
@@ -36,7 +36,7 @@ class PathTestCase(unittest.TestCase):
         prog = program.Program(config.Config())
         md = mbngs.DiscMetadata()
         md.artist = md.sortName = 'Jeff Buckley'
-        md.title = 'Grace'
+        md.releaseTitle = 'Grace'
 
         path = prog.getPath('/tmp', '%A/%d', 'mbdiscid', md, 0)
         self.assertEqual(path,


### PR DESCRIPTION
This pull request extends the supported template variables. Additions:

- `%B`: release barcode (already included but is now allowed)
- `%C`: release catalog number (already included but is now allowed)
- `%c`: release disambiguation comment
- `%D`: disc title without disambiguation
- `%I`: MusicBrainz Disc ID
- `%M`: total number of discs in the chosen release
- `%N`: number of current disc
- `%T`: medium title

When the relative metadata is available, whipper now adds the `TRACKTOTAL`, `DISCTOTAL` and `DISCNUMBER` metadata tags to the audio tracks.

I've also taken the inspiration from pull request #476.

I haven't tested the changes so I can't guarantee that the added features will work as expected.

Resolves #401, resolves #440, resolves #448.