### PR TITLE
Fixed error when ripping using `--keep-going` without specifying `--o…

### DIFF
--- a/whipper/image/image.py
+++ b/whipper/image/image.py
@@ -152,7 +152,7 @@ class ImageVerifyTask(task.MultiSeparateTask):
                 except KeyError:
                     logger.debug('Path not found; Checking '
                                  'if %s is a skipped track', index.path)
-                    if index.path in skipped_tracks:
+                    if os.path.basename(index.path) in skipped_tracks:
                         logger.warning('Missing file %s due to skipped track',
                                        index.path)
                         continue


### PR DESCRIPTION
…utput-directory`

Added `os.path.basename()` to `skipped_tracks` comparison in
`ImageVerifyTask`. When `OUTPUT_DIRECTORY` is at its default '.'
`./` is prepended to the file path of `index.path`, causing the error.

Signed-off-by: blueblots <63152708+blueblots@users.noreply.github.com>