### PR TITLE
Use custom YAML subclass to be compatible with ruamel_yaml>=0.17

### DIFF
--- a/whipper/common/yaml.py
+++ b/whipper/common/yaml.py
@@ -1,0 +1,18 @@
+from ruamel.yaml import YAML as ruamel_YAML
+from ruamel.yaml.compat import StringIO
+
+# https://yaml.readthedocs.io/en/latest/example.html#output-of-dump-as-a-string
+class YAML(ruamel_YAML):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+        self.width = 4000
+        self.default_flow_style = False
+
+    def dump(self, data, stream=None, **kw):
+        inefficient = False
+        if stream is None:
+            inefficient = True
+            stream = StringIO()
+        ruamel_YAML.dump(self, data, stream, **kw)
+        if inefficient:
+            return stream.getvalue()

--- a/whipper/result/logger.py
+++ b/whipper/result/logger.py
@@ -1,12 +1,12 @@
 import time
 import hashlib
 import re
-import ruamel.yaml as yaml
 from ruamel.yaml.comments import CommentedMap as OrderedDict
 
 import whipper
 
 from whipper.common import common
+from whipper.common.yaml import YAML
 from whipper.result import result
 
 
@@ -148,11 +148,12 @@ class WhipperLogger(result.Logger):
         data["EOF"] = "End of status report"
         riplog["Conclusive status report"] = data
 
+        yaml = YAML(
+            typ="rt",
+            pure=True
+        )
         riplog = yaml.dump(
-            riplog,
-            default_flow_style=False,
-            width=4000,
-            Dumper=yaml.RoundTripDumper
+            riplog
         )
         # Add a newline after the "Log creation date" line
         riplog = re.sub(

--- a/whipper/test/test_result_logger.py
+++ b/whipper/test/test_result_logger.py
@@ -3,8 +3,8 @@ import hashlib
 import os
 import re
 import unittest
-import ruamel.yaml
 
+from whipper.common.yaml import YAML
 from whipper.result.result import TrackResult, RipResult
 from whipper.result.logger import WhipperLogger
 
@@ -163,16 +163,14 @@ class LoggerTestCase(unittest.TestCase):
             ))
         )
 
-        yaml = ruamel.yaml.YAML()
+        yaml = YAML(
+            typ='rt',
+            pure=True
+        )
         parsedLog = yaml.load(actual)
         self.assertEqual(
             actual,
-            ruamel.yaml.dump(
-                parsedLog,
-                default_flow_style=False,
-                width=4000,
-                Dumper=ruamel.yaml.RoundTripDumper
-            )
+            yaml.dump(parsedLog)
         )
         log_body = "\n".join(actualLines[:-1]).encode()
         self.assertEqual(


### PR DESCRIPTION
Fixes a DeprecationWarning for ruamel_yaml>=0.17

```
/build/source/whipper/test/test_result_logger.py:167: PendingDeprecationWarning:
dump will be removed, use

  yaml=YAML(typ='unsafe', pure=True)
  yaml.dump(...)

instead
  ruamel.yaml.dump(
/nix/store/lf2qpwvjp3gxgrjkcvcw18d3zlrxsif8-python3.8-ruamel.yaml-0.17.9/lib/python3.8/site-packages/ruamel/yaml/main.py:1364: PendingDeprecationWarning:
dump_all will be removed, use

  yaml=YAML(typ='unsafe', pure=True)
  yaml.dump_all(...)

instead
  return dump_all(
F
======================================================================
FAIL: testLogger (whipper.test.test_result_logger.LoggerTestCase)
----------------------------------------------------------------------
```

:information_source: Subclasses `ruamel.yaml.YAML` as `whipper.common.yaml.YAML` and moves common values for `width` and `default_flow_style` into `whipper.common.yaml.YAML`. `RoundTripDumper`, as I understand it, is the default dumper.

:heavy_check_mark: Tested with ruamel_yaml 0.16.13 and 0.17.9

:question: Not sure about the license header for `whipper.common.yaml`, since this is mostly copy/paste from the ruamel_yaml documentation (https://yaml.readthedocs.io/en/latest/example.html#output-of-dump-as-a-string)