### PR TITLE
Better --prompt Handling

### DIFF
--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -359,8 +359,10 @@ class Program:
 
                 if prompt:
                     guess = (deltas[lowest])[0].mbid
+                    print("\nPlease select a release. You only need to match "
+                          "the last few characters.")
                     release = input(
-                        "\nPlease select a release [%s]: " % guess)
+                        "With no input the release will be [%s]: " % guess)
 
                     if not release:
                         release = guess

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -362,7 +362,8 @@ class Program:
                     print("\nPlease select a release. You only need to match "
                           "the last few characters.")
                     release = input(
-                        "With no input the release will be [%s]: " % guess)
+                        "With no input the release will be [%s]: " %
+                        guess).lower()
 
                     if not release:
                         release = guess


### PR DESCRIPTION
I always use the `--prompt` option to ensure that the correct release is choosen, but the process of choosing one is a bit ambiguous. My first guess was to enter the index number of the displayed release that I wanted (1 for the first one, 2 for the second one and so on) but that was incorrect. I had to look through the source to see how to do it.

So I added a little message for the user to make things more clear. I also made the input case-insensitive so that `25EA4` will match with `25ea4`.