### PR TITLE
Add man page for accuraterip-checksum

### DIFF
--- a/man/accuraterip-checksum.rst
+++ b/man/accuraterip-checksum.rst
@@ -1,0 +1,33 @@
+====================
+accuraterip-checksum
+====================
+
+----------------------------------------------------------
+Compute the AccurateRip checksum of single track WAV files
+----------------------------------------------------------
+
+:Author: Louis-Philippe Véronneau
+:Date: 2022
+:Manual section: 1
+
+Synopsis
+========
+
+| accuraterip-checksum [**options**] *<filename>* *<track_number>* *<total_tracks>*
+
+Options
+=======
+
+| **-h** | **--help**
+|     Show this help message and exit
+
+| **--version**
+|     Show version information
+
+| **--accuraterip-v1** | **--accuraterip-v2**
+|     Explicitly choose AccurateRip checksum version (v2 is the default)
+
+See Also
+========
+
+whipper(1)


### PR DESCRIPTION
The compiled man page looks like this (but with highlights):

```
ACCURATERIP-CHECKSUM(1)                                ACCURATERIP-CHECKSUM(1)

NAME
       accuraterip-checksum - Compute the AccurateRip checksum of single track
       WAV files

SYNOPSIS
       accuraterip-checksum [options] <filename> <track_number> <total_tracks>

OPTIONS
       -h | --help
         Show this help message and exit

       --version
         Show version information

       --accuraterip-v1 | --accuraterip-v2
         Explicitly choose AccurateRip checksum version (v2 is the default)

SEE ALSO
       whipper(1)

AUTHOR
       Louis-Philippe Véronneau

                                     2022              ACCURATERIP-CHECKSUM(1)
```