### PR TITLE
extern.task: replace GLib event loop with asyncio event loop 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     curl \
     eject \
     flac \
-    gir1.2-glib-2.0 \
     git \
     libdiscid0 \
     libiso9660-dev \
@@ -20,7 +19,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     make \
     pkgconf \
     python3-dev \
-    python3-gi \
     python3-musicbrainzngs \
     python3-mutagen \
     python3-pil \

--- a/README.md
+++ b/README.md
@@ -130,8 +130,6 @@ Whipper relies on the following packages in order to run correctly and provide a
   - To avoid bugs it's advised to use `cd-paranoia` versions ≥ **10.2+0.94+2**
   - The package named `libcdio-utils`, available on certain Debian and Ubuntu versions, is affected by a bug: it doesn't include the `cd-paranoia` binary (needed by whipper). Only Debian bullseye (testing) / sid (unstable) and Ubuntu focal (20.04) and later versions have a separate `cd-paranoia` package where the binary is provided. For more details on this issue check the relevant bug reports: [#888053 (Debian)](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=888053), [#889803 (Debian)](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=889803) and [#1750264 (Ubuntu)](https://bugs.launchpad.net/ubuntu/+source/libcdio/+bug/1750264).
 - [cdrdao](http://cdrdao.sourceforge.net/), for session, TOC, pre-gap, and ISRC extraction
-- [GObject Introspection](https://wiki.gnome.org/Projects/GObjectIntrospection), to provide GLib-2.0 methods used by `task.py`
-- [PyGObject](https://pypi.org/project/PyGObject/), required by `task.py`
 - [musicbrainzngs](https://pypi.org/project/musicbrainzngs/), for metadata lookup
 - [mutagen](https://pypi.python.org/pypi/mutagen), for tagging support
 - [setuptools](https://pypi.python.org/pypi/setuptools), for installation, plugins support
@@ -149,7 +147,6 @@ Some dependencies aren't available in the PyPI. They can be probably installed u
 
 - [cd-paranoia](https://github.com/rocky/libcdio-paranoia)
 - [cdrdao](http://cdrdao.sourceforge.net/)
-- [GObject Introspection](https://wiki.gnome.org/Projects/GObjectIntrospection)
 - [libsndfile](http://www.mega-nerd.com/libsndfile/)
 - [flac](https://xiph.org/flac/)
 - [sox](http://sox.sourceforge.net/)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 musicbrainzngs
 mutagen
 pycdio>0.20
-PyGObject
 ruamel.yaml
 setuptools_scm
 discid


### PR DESCRIPTION
Hello! This program is awesome.

This change works towards #5 by replacing the GLib MainLoop that backs `task.py` with `asyncio`'s event loop. The interfaces are extremely similar and this removes a big dependency.

I'm not sure what should be done about #5 after this given that quite a bit of whipper code uses the `Task` interface. Maybe `task.py` and `asyncsub.py` can just be merged into `whipper/common` and later refactored?

---

I tested this by going through the drive setup process from scratch (`whipper drive analyze` and `whipper offset find`), ripping an album, then running `whipper image verify`. I ensured progress calculation worked and no commands got stuck.