### PR TITLE
Fix stripping AccurateRip URL in accurip command

### DIFF
--- a/whipper/command/accurip.py
+++ b/whipper/command/accurip.py
@@ -35,8 +35,13 @@ retrieves and display accuraterip data from the given URL
         self.parser.add_argument('url', action='store',
                                  help="accuraterip URL to load data from")
 
+    def _strip_url_prefix(self, url):
+        if self.options.url.startswith(ACCURATERIP_URL):
+            return self.options.url[len(ACCURATERIP_URL):]
+        return url
+
     def do(self):
-        responses = get_db_entry(self.options.url.lstrip(ACCURATERIP_URL))
+        responses = get_db_entry(self._strip_url_prefix(self.options.url))
 
         count = responses[0].num_tracks
 


### PR DESCRIPTION
I've been trying to learn about AccurateRip database, and I was playing with `whipper accuraterip show` command. I encountered errors when certain URLs were passed as command line argument, e.g.:

```
$ WHIPPER_DEBUG=DEBUG whipper accurip show http://www.accuraterip.com/accuraterip/e/e/d/dBAR-006-000aadee-003920f8-4d0a3d06.bin
DEBUG:whipper.common.config:loaded 1 sections from config file
DEBUG:whipper.common.config:loaded 1 sections from config file
DEBUG:whipper.common.config:loaded 1 sections from config file
DEBUG:whipper.common.config:loaded 1 sections from config file
DEBUG:whipper.common.config:loaded 1 sections from config file
DEBUG:whipper.common.config:loaded 1 sections from config file
DEBUG:whipper.common.accurip:downloading AccurateRip entry from http://www.accuraterip.com/accuraterip/d/dBAR-006-000aadee-003920f8-4d0a3d06.bin
DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): www.accuraterip.com:80
DEBUG:urllib3.connectionpool:http://www.accuraterip.com:80 "GET /accuraterip/d/dBAR-006-000aadee-003920f8-4d0a3d06.bin HTTP/1.1" 404 1245
ERROR:whipper.common.accurip:error retrieving AccurateRip entry: 404 Not Found <Response [404]>
WARNING:whipper.common.accurip:entry not found in AccurateRip database
```

From the debug log above it appears that `whipper` is looking for the wrong ID: `/e/e/d/` specified on the command line somehow became `/d/` in the GET request. The URL with `/e/e/d/` is valid (I can download the `.bin` file from AccurateRip with `wget` or similar tool). The URL with `/d/` is incorrect.

I got similar errors with these four IDs:
* `e/e/d/dBAR-006-000aadee-003920f8-4d0a3d06.bin`
* `c/5/2/dBAR-014-0022f25c-017b5273-d210350e.bin`
* `c/3/6/dBAR-005-0006763c-001e122d-2c075305.bin`
* `a/e/5/dBAR-006-0009f5ea-0034b0dd-4309e706.bin`

I believe this is a bug caused by incorrect usage of `lstrip()` to remove a leading substring. An argument to `lstrip()` is a set of characters to remove, not a substring. `ACCURATERIP_URL` contains a `/` character, and letters `a`, `c` and `e`, which are also hex digits. All my four "problematic" IDs begin with these characters.

This PR presents a possible solution, assuming the intention is to remove a known leading substring from `url`.