### PR TITLE
Zero pad discNumber and discTotal in templates like track_number

### DIFF
--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -222,8 +222,8 @@ class Program:
             v['B'] = metadata.barcode
             v['C'] = metadata.catalogNumber
             v['c'] = metadata.releaseDisambCmt
-            v['M'] = metadata.discTotal
-            v['N'] = metadata.discNumber
+            v['M'] = '%02d' % (metadata.discTotal or 0)
+            v['N'] = '%02d' % (metadata.discNumber or 1)
             v['T'] = metadata.mediumTitle
             if metadata.releaseType:
                 v['R'] = metadata.releaseType


### PR DESCRIPTION
Changed to zero-pad to two digits disc number template variables `%M` and `%N` just like track number `%t`.