### PR TITLE
Add config file option to set cdparanoia command

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,6 @@ path_filter_posix = True		; replace illegal chars in *nix OSes with _
 path_filter_vfat = False		; replace illegal chars in VFAT filesystems with _
 path_filter_whitespace = False		; replace all whitespace chars with _
 path_filter_printable = False		; replace all non printable ASCII chars with _
-# cdparanoia = cdparanoia		; cdparanoia executable to use.  Default is cd-paranoia
 
 [musicbrainz]
 server = https://musicbrainz.org	; use MusicBrainz server at host[:port]
@@ -264,6 +263,14 @@ server = https://musicbrainz.org	; use MusicBrainz server at host[:port]
 defeats_cache = True			; whether the drive is capable of defeating the audio cache
 read_offset = 6				; drive read offset in positive/negative frames (no leading +)
 # do not edit the values 'vendor', 'model', and 'release'; they are used by whipper to match the drive
+
+[drive:PIONEER%20%3ABD-RW%20%20%20BDR-209D%3A1.10]
+defeats_cache = True
+read_offset = 667
+cdparanoia = cdparanoia			; cdparanoia executable to use.  Default is cd-paranoia
+					; cd-paranoia has a bug that makes drives with large read_offset
+					; unusable, see https://github.com/whipper-team/whipper/issues/234
+
 
 # command line defaults for `whipper cd rip`
 [whipper.cd.rip]

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ path_filter_posix = True		; replace illegal chars in *nix OSes with _
 path_filter_vfat = False		; replace illegal chars in VFAT filesystems with _
 path_filter_whitespace = False		; replace all whitespace chars with _
 path_filter_printable = False		; replace all non printable ASCII chars with _
+# cdparanoia = cdparanoia		; cdparanoia executable to use.  Default is cd-paranoia
 
 [musicbrainz]
 server = https://musicbrainz.org	; use MusicBrainz server at host[:port]

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -179,16 +179,26 @@ class _CD(BaseCommand):
 
         # result
 
-        self.program.result.cdrdaoVersion = cdrdao.version()
-        self.program.result.cdparanoiaVersion = \
-            cdparanoia.getCdParanoiaVersion()
+
         info = drive.getDeviceInfo(self.device)
         if info:
+            try:
+                cdparanoia_cmd = self.config.getCdparanoia(*info)
+                logger.info("using configured cdparanoia command %s", cdparanoia_cmd)
+                cdparanoia.setCdParanoiaCommand(cdparanoia_cmd)
+            except KeyError:
+                pass
+
             try:
                 self.program.result.cdparanoiaDefeatsCache = \
                     self.config.getDefeatsCache(*info)
             except KeyError as e:
                 logger.debug('got key error: %r', (e, ))
+
+        self.program.result.cdrdaoVersion = cdrdao.version()
+        self.program.result.cdparanoiaVersion = \
+            cdparanoia.getCdParanoiaVersion()
+
         self.program.result.artist = self.program.metadata \
             and self.program.metadata.artist \
             or 'Unknown Artist'

--- a/whipper/command/main.py
+++ b/whipper/command/main.py
@@ -13,12 +13,17 @@ from whipper.command.basecommand import BaseCommand
 from whipper.common import common, directory, config
 from whipper.extern.task import task
 from whipper.program.utils import eject_device
+from whipper.program import cdparanoia
 
 import logging
 logger = logging.getLogger(__name__)
 
 
 def main():
+    cdparanoia_cmd = config.Config().get('main', 'cdparanoia')
+    if cdparanoia_cmd:
+        cdparanoia.setCdParanoiaCommand(cdparanoia_cmd)
+
     server = config.Config().get_musicbrainz_server()
     https_enabled = server['scheme'] == 'https'
     try:

--- a/whipper/common/config.py
+++ b/whipper/common/config.py
@@ -101,6 +101,10 @@ class Config:
         option = self._getDriveOption(vendor, model, release, 'defeats_cache')
         return option == 'True'
 
+    def getCdparanoia(self, vendor, model, release):
+        """Get the cdparanoia command for the given drive."""
+        return self._getDriveOption(vendor, model, release, 'cdparanoia')
+
     def _findDriveSection(self, vendor, model, release):
         for name in self._parser.sections():
             if not name.startswith('drive:'):

--- a/whipper/program/cdparanoia.py
+++ b/whipper/program/cdparanoia.py
@@ -35,6 +35,7 @@ from whipper.extern.task import task
 import logging
 logger = logging.getLogger(__name__)
 
+cdparanoia = 'cd-paranoia'
 
 class FileSizeError(Exception):
     """The given path does not have the expected size."""
@@ -68,6 +69,12 @@ _PROGRESS_RE = re.compile(r"""
 """, re.VERBOSE)
 
 _ERROR_RE = re.compile("^scsi_read error:")
+
+
+def setCdParanoiaCommand(cmd):
+    global cdparanoia
+    cdparanoia = cmd
+
 
 # from reading cdparanoia source code, it looks like offset is reported in
 # number of single-channel samples, ie. 2 bytes (word) per unit, and absolute
@@ -271,10 +278,10 @@ class ReadTrackTask(task.Task):
 
         bufsize = 1024
         if self._overread:
-            argv = ["cd-paranoia", "--stderr-progress",
+            argv = [cdparanoia, "--stderr-progress",
                     "--sample-offset=%d" % self._offset, "--force-overread", ]
         else:
-            argv = ["cd-paranoia", "--stderr-progress",
+            argv = [cdparanoia, "--stderr-progress",
                     "--sample-offset=%d" % self._offset, ]
         if self._device:
             argv.extend(["--force-cdrom-device", self._device, ])
@@ -573,7 +580,7 @@ _VERSION_RE = re.compile(
 
 def getCdParanoiaVersion():
     getter = common.VersionGetter('cd-paranoia',
-                                  ["cd-paranoia", "-V"],
+                                  [cdparanoia, "-V"],
                                   _VERSION_RE,
                                   "%(version)s %(release)s")
 
@@ -599,7 +606,7 @@ class AnalyzeTask(ctask.PopenTask):
     def __init__(self, device=None):
         # cdparanoia -A *always* writes cdparanoia.log
         self.cwd = tempfile.mkdtemp(suffix='.whipper.cache')
-        self.command = ['cd-paranoia', '-A']
+        self.command = [cdparanoia, '-A']
         if device:
             self.command += ['-d', device]
 


### PR DESCRIPTION
This allows for setting the cdparanoia executable via the config file like so:

```
[main]
cdparanoia = cdparanoia
```

This does not allow for setting the option via the command line, as that would have required more extensive changes, since cdparanoia is used for multiple commands.  But this does now allow for code to be added to make `whipper` smarter and possibly able to detect and self-configure to use the best cdparanoia version, if multiple versions are available.

Resolves #220
Partially addresses #244
Provides workaround for #234
