### PR TITLE
Save FLAC file after embedding cover art

### DIFF
--- a/whipper/common/encode.py
+++ b/whipper/common/encode.py
@@ -157,5 +157,6 @@ class EmbedPictureTask(task.Task):
         if flac_pic:
             w = FLAC(self.track_path)
             w.add_picture(flac_pic)
+            w.save()
 
         self.stop()


### PR DESCRIPTION
Without this call to `.save()`, I don't think the FLAC file _with cover art_ is ever persisted. (See `TaggingTask._tag`, which already calls `w.save()`.) I wish I had noticed this before ripping a couple hundred CDs :sweat_smile: 

Thanks very much for your work on whipper, it's been instrumental in digitizing my CD collection!