### PR TITLE
Migrate to PEP517-compliant pyproject.toml build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,51 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "whipper"
+authors = [
+    {name = "The Whipper Team"},
+]
+description = "A CD-DA ripper prioritising accuracy over speed"
+requires-python = ">=3.6"
+readme = "README.md"
+license = {file = "LICENSE"}
+classifiers = [
+    "Environment :: Console",
+    "Intended Audience :: End Users/Desktop",
+    "Topic :: Multimedia :: Sound/Audio",
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: GNU General Public License v3",
+]
+dependencies = [
+    "musicbrainzngs",
+    "mutagen",
+    "pycdio",
+    "PyGObject",
+    "ruamel.yaml",
+    "setuptools_scm",
+    "discid",
+]
+dynamic = ["version"]
+
+[project.urls]
+Home = "https://github.com/whipper-team/whipper"
+
+[project.optional-dependencies]
+cover_art = ["pillow"]
+docs = ["docutils"]
+
+[project.scripts]
+whipper = "whipper.command.main:main"
+
+# This is necessary, since whipper uses a flat-layout, but has as a 'src'
+# directory and setuptools gets confused otherwise.
+[tool.setuptools.packages.find]
+namespaces = false
+
+[tool.setuptools.package-data]
+"whipper" = ["**"]
+
+[tool.setuptools_scm]
+# Empty, but needed to enable SCM

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ whipper = "whipper.command.main:main"
 namespaces = false
 
 [tool.setuptools.package-data]
-"whipper" = ["test/*"]
+"whipper" = ["test/**"]
 
 [tool.setuptools_scm]
 # Empty, but needed to enable SCM

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ whipper = "whipper.command.main:main"
 namespaces = false
 
 [tool.setuptools.package-data]
-"whipper" = ["**"]
+"whipper" = ["test/*"]
 
 [tool.setuptools_scm]
 # Empty, but needed to enable SCM

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,11 @@
-from setuptools import setup, find_packages, Extension
+from setuptools import Extension, setup
 
 setup(
-    name="whipper",
-    use_scm_version=True,
-    description="a secure cd ripper preferring accuracy over speed",
-    author=['Thomas Vander Stichele', 'The Whipper Team'],
-    maintainer=['The Whipper Team'],
-    url='https://github.com/whipper-team/whipper',
-    license='GPL3',
-    python_requires='>=3.6',
-    packages=find_packages(),
-    setup_requires=['setuptools_scm'],
     ext_modules=[
-        Extension('accuraterip',
-                  libraries=['sndfile'],
-                  sources=['src/accuraterip-checksum.c'])
-    ],
-    extras_require={
-        'cover_art': ["pillow"]
-    },
-    entry_points={
-        'console_scripts': [
-            'whipper = whipper.command.main:main'
-         ]
-    },
-    data_files=[
-        ('share/metainfo', ['com.github.whipper_team.Whipper.metainfo.xml']),
-    ],
-    scripts=[
-        'scripts/accuraterip-checksum',
-    ],
+        Extension(
+            name="accuraterip",
+            libraries=['sndfile'],
+            sources=["src/accuraterip-checksum.c"],
+        ),
+    ]
 )


### PR DESCRIPTION
This PR migrates the build system from the old `setup.py` to the new PEP517-compliant `pyproject.toml`-based one. I stuck with `setuptools`, since this is what we were already using.

Note that sadly, to my knowledge, it is not currently possible to install scripts like it was before, which means that the `accuraterip-checksum` script has to be installed manually.

The `setup.py` file isn't removed either, as it is still needed to build the C extension.

Happy to change things if necessary, but AFAIK this works fine, as I'm building the Debian package with it.

Cheers,