### PR TITLE
Dockerfile: Fix bug by adding group by id not name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN ldconfig
 # add user (+ group workaround for ArchLinux)
 RUN useradd -m worker --uid ${uid} -G cdrom \
     && if [ -n "${optical_gid}" ]; then groupadd -f -g "${optical_gid}" optical \
-    && usermod -a -G optical worker; fi \
+    && usermod -a -G "${optical_gid}" worker; fi \
     && mkdir -p /output /home/worker/.config/whipper \
     && chown worker: /output /home/worker/.config/whipper
 VOLUME ["/home/worker/.config/whipper", "/output"]


### PR DESCRIPTION
I was running into this issue on solus trying to build the image with a specified gid when the gid (15) already existed.

When a group already exists with the specified gid, `usermod -f` will silently added the group with a default new gid (eg 1001). So `worker` ends up with an extra useless group rather than the one specified. This fixes the issue by adding the group by the gid rather than by the name, so `worker` always ends up with the gid you want (even if that isn't the newly created `optical` group)