### PR TITLE
Default %S to 'Unknown Artist'

### DIFF
--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -195,7 +195,7 @@ class Program:
         assert isinstance(outdir, str), "%r is not str" % outdir
         assert isinstance(template, str), "%r is not str" % template
         v = {}
-        v['A'] = 'Unknown Artist'
+        v['S'] = v['A'] = 'Unknown Artist'
         v['I'] = v['d'] = v['D'] = mbdiscid  # fallback for title
         v['r'] = 'unknown'
         v['R'] = 'Unknown'


### PR DESCRIPTION
When metadata is absent,
the %S template variable does not have a default value set in the dictionary,
which can cause a "KeyError: 'S'" error.

While %A defaults to 'Unknown Artist' and %S might conventionally default to 'Artist, Unknown',
defaulting %S to that is unnecessary,
because manual tagging typically follows to assign the correct name.
Therefore, I default %S to 'Unknown Artist', just like %A.