### PR TITLE
Make distutils optional

### DIFF
--- a/whipper/command/main.py
+++ b/whipper/command/main.py
@@ -7,7 +7,6 @@ import pkg_resources
 import musicbrainzngs
 import site
 import whipper
-from distutils.sysconfig import get_python_lib
 from whipper.command import cd, offset, drive, image, accurip, mblookup
 from whipper.command.basecommand import BaseCommand
 from whipper.common import common, directory, config
@@ -38,11 +37,16 @@ def main():
     # Find whipper's plugins paths (local paths have higher priority)
     plugins_p = [directory.data_path('plugins')]  # local path (in $HOME)
     if hasattr(sys, 'real_prefix'):  # no getsitepackages() in virtualenv
-        plugins_p.append(
-            get_python_lib(plat_specific=False, standard_lib=False,
-                           prefix='/usr/local') + '/whipper/plugins')
-        plugins_p.append(get_python_lib(plat_specific=False,
-                         standard_lib=False) + '/whipper/plugins')
+        try:
+            from distutils.sysconfig import get_python_lib
+            plugins_p.append(
+                get_python_lib(plat_specific=False, standard_lib=False,
+                            prefix='/usr/local') + '/whipper/plugins')
+            plugins_p.append(get_python_lib(plat_specific=False,
+                            standard_lib=False) + '/whipper/plugins')
+        except ModuleNotFoundError:
+            logger.critical("Failed to import distutils. Some plugins might "
+                         "be unavailable.")
     else:
         plugins_p += [x + '/whipper/plugins' for x in site.getsitepackages()]
 


### PR DESCRIPTION
As #611 states, `distutils` has been removed from Python 3.12 onwards. This means that the current release of whipper does not run on Ubuntu 24.04 (current LTS). This PR provides a very minimal fix for this by:

* moving the import of distutils to where it is required
* also catching ModuleNotFoundErrors occuring from 3.12 onwards

I know this is not a perfect fix by any means. However, it is sufficient for me to successfully use whipper and I could find it in 3mins of looking. I really don't know anything about whipper and not much about `distutils` or how to replace its deprecated functionality properly.

Partially resolves #611  

Anyone else who stumbles upon this: If you don't run whipper in a virtualenv (e.g. if you installed it via `apt`), it is enough to just delete the import at the top of the file. Just edit the last file mentioned in the error message (at `/usr/lib/python3/dist-packages/whipper/command/main.py` for me) and delete the line `from distutils.sysconfig import get_python_lib`  (around line 10).