### PR TITLE
Add option to keep unverified tracks. Fixes #612.

### DIFF
--- a/man/whipper-cd-rip.rst
+++ b/man/whipper-cd-rip.rst
@@ -73,6 +73,10 @@ Options
 |     continue ripping further tracks instead of giving up if a track can't be
 |     ripped
 
+| **-u** | **--keep-unverified**
+|     keep unverified tracks instead of deleting the data if a track can't be
+|     verified
+
 Template schemes
 ================
 

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -231,6 +231,9 @@ class Rip(_CD):
     skipped_tracks = []
     # this holds tracks that fail to rip -
     # currently only used when the --keep-going option is used
+    unverified_tracks = []
+    # this holds tracks that failed to verify -
+    # currently only used when the --keep-unverified option is used
     description = """
 Rips a CD.
 
@@ -326,6 +329,11 @@ Log files will log the path to tracks relative to this directory.
                                  help="continue ripping further tracks "
                                  "instead of giving up if a track "
                                  "can't be ripped")
+        self.parser.add_argument('-u', '--keep-unverified',
+                                 action='store_true',
+                                 help="keep unverified (partial) results "
+                                 "instead of deleleting the data if a track "
+                                 "can't be verified")
 
     def handle_arguments(self):
         self.options.output_directory = os.path.expanduser(
@@ -481,7 +489,8 @@ Log files will log the path to tracks relative to this directory.
                                                   number,
                                                   len(self.itable.tracks),
                                                   extra),
-                                              coverArtPath=self.coverArtPath)
+                                              coverArtPath=self.coverArtPath,
+                                              keep=self.options.keep_unverified)
                         break
                     # FIXME: catching too general exception (Exception)
                     except Exception as e:
@@ -492,7 +501,15 @@ Log files will log the path to tracks relative to this directory.
                     tries -= 1
                     logger.critical('giving up on track %d after %d times',
                                     number, tries)
-                    if self.options.keep_going:
+                    if self.options.keep_unverified and not number == 0:
+                        logger.warning("track %d failed to rip. keeping unverified file.", number)
+                        logger.debug("adding %s to unverified_tracks",
+                                     trackResult)
+                        self.unverified_tracks.append(trackResult)
+                        logger.debug("unverified_tracks = %s",
+                                     self.unverified_tracks)
+                        trackResult.unverified = True
+                    elif self.options.keep_going:
                         logger.warning("track %d failed to rip.", number)
                         logger.debug("adding %s to skipped_tracks",
                                      trackResult)
@@ -504,7 +521,7 @@ Log files will log the path to tracks relative to this directory.
                         raise RuntimeError("track can't be ripped. "
                                            "Rip attempts number is equal "
                                            "to {}".format(self.options.max_retries))
-                if trackResult in self.skipped_tracks:
+                if trackResult in (self.skipped_tracks or self.unverified_tracks):
                     print("Skipping CRC comparison for track %d "
                           "due to rip failure" % number)
                 else:
@@ -572,6 +589,8 @@ Log files will log the path to tracks relative to this directory.
         logger.debug('writing m3u file for %r', discName)
         self.program.write_m3u(discName)
 
+        if len(self.unverified_tracks) > 0:
+            self.program.unverified_tracks = self.unverified_tracks
         if len(self.skipped_tracks) > 0:
             logger.warning("the generated cue sheet references %d track(s) "
                            "which failed to rip so the associated file(s) "
@@ -591,6 +610,10 @@ Log files will log the path to tracks relative to this directory.
             logger.warning('%d tracks have been skipped from this rip attempt',
                            len(self.skipped_tracks))
             return 5
+        elif len(self.unverified_tracks) > 0:
+            logger.warning('%d tracks could not be verified from this rip attempt',
+                           len(self.unverified_tracks))
+            return 6
 
 
 class CD(BaseCommand):

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -60,6 +60,7 @@ class Program:
     outdir = None
     result = None
     skipped_tracks = None
+    unverified_tracks = None
 
     def __init__(self, config, record=False):
         """
@@ -562,7 +563,7 @@ class Program:
         return ret
 
     def ripTrack(self, runner, trackResult, offset, device, taglist,
-                 overread, what=None, coverArtPath=None):
+                 overread, what=None, coverArtPath=None, keep=False):
         """
         Rip and store a track of the disc.
 
@@ -606,7 +607,8 @@ class Program:
                                            device=device,
                                            taglist=taglist,
                                            what=what,
-                                           coverArtPath=coverArtPath)
+                                           coverArtPath=coverArtPath,
+                                           keep=keep)
 
         runner.run(t)
 

--- a/whipper/program/cdparanoia.py
+++ b/whipper/program/cdparanoia.py
@@ -439,8 +439,10 @@ class ReadVerifyTrackTask(task.MultiSeparateTask):
     _tmpwavpath = None
     _tmppath = None
 
+    _keep = False
+
     def __init__(self, path, table, start, stop, overread, offset=0,
-                 device=None, taglist=None, what="track", coverArtPath=None):
+                 device=None, taglist=None, what="track", coverArtPath=None, keep=False):
         """
         Init ReadVerifyTrackTask.
 
@@ -470,6 +472,8 @@ class ReadVerifyTrackTask(task.MultiSeparateTask):
         os.fchmod(fd, 0o644)
         os.close(fd)
         self._tmpwavpath = tmppath
+
+        self._keep = keep
 
         from whipper.common import checksum
 
@@ -547,9 +551,11 @@ class ReadVerifyTrackTask(task.MultiSeparateTask):
                 # delete the unencoded file
                 os.unlink(self._tmpwavpath)
 
-                if not self.exception:
+                if not self.exception or self._keep:
                     try:
                         logger.debug('moving to final path %r', self.path)
+                        if self.exception:
+                            logger.debug('keeping unverified result')
                         shutil.move(self._tmppath, self.path)
                     # FIXME: catching too general exception (Exception)
                     except Exception as e:

--- a/whipper/result/logger.py
+++ b/whipper/result/logger.py
@@ -16,6 +16,7 @@ class WhipperLogger(result.Logger):
     _inARDatabase = 0
     _errors = False
     _skippedTracks = False
+    _unverifiedTracks = False
 
     def log(self, ripResult, epoch=time.time()):
         """Return logfile as string."""
@@ -142,6 +143,8 @@ class WhipperLogger(result.Logger):
             message = "There were errors"
         elif self._skippedTracks:
             message = "Some tracks were not ripped (skipped)"
+        elif self._unverifiedTracks:
+            message = "Some tracks could not be verified (but were kept)"
         else:
             message = "No errors occurred"
         data["Health status"] = message
@@ -250,6 +253,10 @@ class WhipperLogger(result.Logger):
         if trackResult.skipped:
             track["Status"] = "Track not ripped (skipped)"
             self._skippedTracks = True
+        # Check if the track has failed verification, but has been kept
+        elif trackResult.unverified:
+            track["Status"] = "Copy NOT OK (unverified file kept)"
+            self._unverifiedTracks = True
         # Check if Test & Copy CRCs are equal
         elif trackResult.testcrc == trackResult.copycrc:
             track["Status"] = "Copy OK"

--- a/whipper/result/result.py
+++ b/whipper/result/result.py
@@ -39,6 +39,7 @@ class TrackResult:
     AR = None
     classVersion = 3
     skipped = False
+    unverified = False
 
     def __init__(self):
         """


### PR DESCRIPTION
Add a -u/--keep-unverified option that keeps the most recent attempt of ripping a track that failed verification.

The logging might be inconsistent in that the unverifiable track is mentioned as bein skipped in some log messages.
