### PR TITLE
Only look for this rip's log file in output directory

### DIFF
--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -378,8 +378,8 @@ Log files will log the path to tracks relative to this directory.
                                         self.program.metadata)
         dirname = os.path.dirname(discName)
         if os.path.exists(dirname):
-            logs = glob.glob(os.path.join(glob.escape(dirname), '*.log'))
-            if logs:
+            log_file = discName + '.log'
+            if os.path.exists(log_file):
                 msg = ("output directory %s is a finished rip" % dirname)
                 logger.debug(msg)
                 raise RuntimeError(msg)


### PR DESCRIPTION
I have whipper setup with these options to adhere to the filename conventions of the Plex Media Server:
```ini
[whipper.cd.rip]
track_template = %%A/%%D/%%N%%t - %%n
disc_template = %%A/%%D/%%N
```
For multi-disk releases, this ends up creating `1.log` and `2.log` log files in the same directory. If I attempt to rip one disk after the other is already finished, Whipper will claim the rip is already finished (since there's already *a* log file in the directory)

This patch resolves that issue by only looking for the log file of the actual rip