### PR TITLE
Always invoke the root command as `whipper`

### DIFF
--- a/whipper/command/main.py
+++ b/whipper/command/main.py
@@ -52,7 +52,7 @@ def main():
     )
     list(map(pkg_resources.working_set.add, distributions))
     try:
-        cmd = Whipper(sys.argv[1:], os.path.basename(sys.argv[0]), None)
+        cmd = Whipper(sys.argv[1:], 'whipper', None)
         ret = cmd.do()
     except SystemError as e:
         logger.critical("SystemError: %s", e)


### PR DESCRIPTION
When installing from source & launching using `python -m whipper`, `sys.argv[0]` ends up as `<path to source checkout>/whipper/__main__.py`. In turn, `__main__.py.foo.bar` is used for lookups in the config file, instead of `whipper.foo.bar`, which means the config file is only partially respected when running from source

Resolve this by hardcoding `whipper` as the program name