### PR TITLE
Add `WHIPPER_COLOR_LOG` env var to color log output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
                   sources=['src/accuraterip-checksum.c'])
     ],
     extras_require={
-        'cover_art': ["pillow"]
+        'cover_art': ["pillow"],
+        'color_log': ["coloredlogs"]
     },
     entry_points={
         'console_scripts': [

--- a/whipper/__init__.py
+++ b/whipper/__init__.py
@@ -14,8 +14,17 @@ except (DistributionNotFound, RequirementParseError):
 level = logging.INFO
 if 'WHIPPER_DEBUG' in os.environ:
     level = os.environ['WHIPPER_DEBUG'].upper()
+
+log_init_func = logging.basicConfig
+if 'WHIPPER_COLOR_LOG' in os.environ:
+    import coloredlogs
+    def init_coloredlogs(**kwargs):
+        # coloredlogs comes with its own log format, we don't want to use that
+        coloredlogs.install(fmt=logging.BASIC_FORMAT, **kwargs)
+    log_init_func = init_coloredlogs
+
 if 'WHIPPER_LOGFILE' in os.environ:
-    logging.basicConfig(filename=os.environ['WHIPPER_LOGFILE'],
-                        filemode='w', level=level)
+    log_init_func(filename=os.environ['WHIPPER_LOGFILE'],
+                  filemode='w', level=level)
 else:
-    logging.basicConfig(stream=sys.stderr, level=level)
+    log_init_func(stream=sys.stderr, level=level)


### PR DESCRIPTION
If `WHIPPER_COLOR_LOG` is set, whipper will now attempt to import the [`coloredlogs`](<https://pypi.org/project/coloredlogs/>) package and install it to add color to log output

I've found this to be much more readable, especially if there's one warning/error among a sea of info messages (say if one track of a disc failed to rip)

Note that this only affects the log printed to stdout, not the rip log files. `coloredlogs` also makes sure that the output stream is a tty before enabling color, so piped output still works fine