### PR TITLE
Make sure to always print out the full release id

### DIFF
--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -373,7 +373,7 @@ class Program:
                 logger.debug('asked for release %r, only kept %r', release,
                              metadatas)
                 if len(metadatas) == 1:
-                    logger.info('picked requested release id %s', release)
+                    logger.info('picked requested release id %s', metadatas[0].mbid)
                     print('Artist: %s' % metadatas[0].artist)
                     print('Title : %s' % metadatas[0].releaseTitle)
                 elif not metadatas:


### PR DESCRIPTION
In the case that multiple releases match a disc ID & `prompt` is enabled, `release` may not contain the full ID (`release` is the input by the user, which may only be the last few digits of the ID). Printing `metadatas[0].mbid` makes more sense IMO, since that'll always be complete