### PR TITLE
Make exception handling for cover art fetching more tolerant

### DIFF
--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -529,7 +529,7 @@ class Program:
         logger.debug('fetching cover art for release: %r', release_id)
         try:
             data = musicbrainzngs.get_image_front(release_id, 500)
-        except musicbrainzngs.ResponseError as e:
+        except musicbrainzngs.WebServiceError as e:
             logger.error('error fetching cover art: %r', e)
             return
 


### PR DESCRIPTION
Use the parent class WebServiceError to cover all errors related to MusicBrainz API requests (ResponseError, NetworkError and AuthenticationError)