### PR TITLE
Keep working if the HTOA track couldn't be ripped

### DIFF
--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -527,10 +527,13 @@ Log files will log the path to tracks relative to this directory.
                                  'threshold, disregarding', trackResult.peak)
                     self.itable.setFile(1, 0, None,
                                         self.itable.getTrackStart(1), number)
-                    logger.debug('unlinking %r', trackResult.filename)
-                    os.unlink(trackResult.filename)
+                    if os.path.exists(trackResult.filename):
+                        logger.debug('unlinking %r', trackResult.filename)
+                        os.unlink(trackResult.filename)
+                        logger.info('HTOA discarded, contains digital silence')
+                    else:
+                        logger.info('HTOA could not be ripped, discarded')
                     trackResult.filename = None
-                    logger.info('HTOA discarded, contains digital silence')
                 else:
                     self.itable.setFile(1, 0, trackResult.filename,
                                         self.itable.getTrackStart(1), number)


### PR DESCRIPTION
Fixes this error when the HTOA can't be ripped (e.g. partially damaged disc):

```
MusicBrainz disc id VyMZhm9Bcmprfna0UrKFaqcUleg-
MusicBrainz lookup URL https://musicbrainz.org/cdtoc/attach?toc=1+15+313425+183+24138+47288+64725+85848+104553+130078+152693+175438+194410+220358+223838+249343+264583+285495&tracks=15&id=VyMZhm9Bcmprfna0UrKFaqcUleg-
Disc duration: 01:09:36.560, 15 audio tracks
INFO:whipper.common.mbngs:wrote releases VyMZhm9Bcmprfna0UrKFaqcUleg- to whipper.releases.VyMZhm9Bcmprfna0UrKFaqcUleg-.json
INFO:whipper.common.mbngs:wrote release cacfd5b3-6b6c-4a59-8fc6-370189dad88a to whipper.release.cacfd5b3-6b6c-4a59-8fc6-370189dad88a.json

Matching releases:

Artist   : Jean-Louis Aubert
Title    : Bleu blanc vert
Duration : 01:09:20.504
URL      : https://musicbrainz.org/release/cacfd5b3-6b6c-4a59-8fc6-370189dad88a
Release  : cacfd5b3-6b6c-4a59-8fc6-370189dad88a
Type     : Album
Barcode  : 077778682424
Country  : France
Cat no(s): 868242

Track 1 finished, found 7284 Q sub-channels with CRC errors
Track 2 finished, found 4706 Q sub-channels with CRC errors
Track 3 finished, found 3175 Q sub-channels with CRC errors
Track 4 finished, found 3001 Q sub-channels with CRC errors
Track 5 finished, found 2083 Q sub-channels with CRC errors
Track 6 finished, found 1491 Q sub-channels with CRC errors
Track 7 finished, found 589 Q sub-channels with CRC errors
Track 8 finished, found 615 Q sub-channels with CRC errors
Track 9 finished, found 257 Q sub-channels with CRC errors
Track 10 finished, found 231 Q sub-channels with CRC errors
Track 11 finished, found 21 Q sub-channels with CRC errors
Track 12 finished, found 405 Q sub-channels with CRC errors
Track 13 finished, found 265 Q sub-channels with CRC errors
Track 14 finished, found 298 Q sub-channels with CRC errors
Track 15 finished, found 585 Q sub-channels with CRC errors
INFO:whipper.program.cdrdao:creating output directory /home/loic/Musik/new rips/Jean-Louis Aubert/Bleu blanc vert (1989)
INFO:whipper.command.cd:found Hidden Track One Audio from frame 0 to 32
INFO:whipper.command.cd:ripping track 0 of 15: 00 - Hidden Track One Audio - Jean-Louis Aubert.flac
INFO:whipper.command.cd:ripping track 0 of 15 (try 2): 00 - Hidden Track One Audio - Jean-Louis Aubert.flac
INFO:whipper.command.cd:ripping track 0 of 15 (try 3): 00 - Hidden Track One Audio - Jean-Louis Aubert.flac
INFO:whipper.command.cd:ripping track 0 of 15 (try 4): 00 - Hidden Track One Audio - Jean-Louis Aubert.flac
INFO:whipper.command.cd:ripping track 0 of 15 (try 5): 00 - Hidden Track One Audio - Jean-Louis Aubert.flac
CRITICAL:whipper.command.cd:giving up on track 0 after 5 times
WARNING:whipper.command.cd:track 0 failed to rip.
Skipping CRC comparison for track 0 due to rip failure
ERROR:__main__:Traceback (most recent call last):
          File "/home/loic/devel/musique/whipper/./batch-whipper.py", line 160, in main
    ret = rip.do()
          File "/home/loic/devel/musique/whipper/whipper/command/basecommand.py", line 141, in do
    return self.cmd.do()
           ~~~~~~~~~~~^^
          File "/home/loic/devel/musique/whipper/whipper/command/basecommand.py", line 141, in do
    return self.cmd.do()
           ~~~~~~~~~~~^^
          File "/home/loic/devel/musique/whipper/whipper/command/cd.py", line 203, in do
    ret = self.doCommand()
          File "/home/loic/devel/musique/whipper/whipper/command/cd.py", line 548, in doCommand
    _ripIfNotRipped(0)
    ~~~~~~~~~~~~~~~^^^
          File "/home/loic/devel/musique/whipper/whipper/command/cd.py", line 531, in _ripIfNotRipped
    os.unlink(trackResult.filename)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
        FileNotFoundError: [Errno 2] No such file or directory: '/home/loic/Musik/new rips/Jean-Louis Aubert/Bleu blanc vert (1989)/00 - Hidden Track One Audio - Jean-Louis Aubert.flac'
```