### PR TITLE
Fix text formatting for track rip failures

### DIFF
--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -493,7 +493,7 @@ Log files will log the path to tracks relative to this directory.
                     logger.critical('giving up on track %d after %d times',
                                     number, tries)
                     if self.options.keep_going:
-                        logger.warning("track %d failed to rip.", number)
+                        logger.warning("track %d failed to rip." % number)
                         logger.debug("adding %s to skipped_tracks",
                                      trackResult)
                         self.skipped_tracks.append(trackResult)


### PR DESCRIPTION
When a track fails to rip, instead of printing

> track %d failed to rip. 5

we should print the following

> track 5 failed to rip.