### PR TITLE
Remove dead communities from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,11 +435,6 @@ You can find us and talk about the project on:
 - IRC: **`#whipper`** channel on the [Libera.Chat](ircs://irc.libera.chat:6697) network
   - See [Libera.Chat’s guide on how to connect](https://libera.chat/guides/connect)
     - Or just use the [Kiwi IRC web client](https://kiwiirc.com/nextclient/irc.libera.chat/?#whipper)
-- Matrix (the room is a portal to Libera Chat's IRC channel)
-  - Join to the room named **`#whipper`** (**`libera.chat`** is the homeserver)
-  - Use Matrix's invite link for [#whipper:libera.chat](https://matrix.to/#/#whipper:libera.chat)
-  - Access Matrix through the [Element web client](https://app.element.io/#/room/#whipper:libera.chat)
-- [Redacted thread (official)](https://redacted.ch/forums.php?action=viewthread&threadid=150)
 
 Other relevant links:
 - [Whipper - Hydrogenaudio Knowledgebase](https://wiki.hydrogenaud.io/index.php?title=Whipper)


### PR DESCRIPTION
# Matrix

Remove Matrix information as Matrix <-> Libera IRC bridges have been sunset since 2023

https://matrix.org/blog/2023/11/28/shutting-down-bridge-to-libera-chat/

https://libera.chat/news/official-matrix-bridge-farewell

https://libera.chat/guides/matrix

# redacted.ch

Remove redacted.ch thread link

I am unaware of what redacted.ch has historically been, but currently the domain seems to be used for adware redirects, removing as it could even be used for malware.

---

Also to note that for some reason the kiwi IRC webclient link does not connect to IRC. I can amend its removal too but I would recommend replacing it with another IRC webclient link.

> We couldn't connect to that server :(
> Unknown error 