### PR TITLE
Migrate license metadata to SPDX expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@ authors = [
 description = "A CD-DA ripper prioritising accuracy over speed"
 requires-python = ">=3.6"
 readme = "README.md"
-license = {file = "LICENSE"}
+license = "GPL-3.0-only"
+license-files = ["LICENSE"]
 classifiers = [
     "Environment :: Console",
     "Intended Audience :: End Users/Desktop",
     "Topic :: Multimedia :: Sound/Audio",
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
 dependencies = [
     "musicbrainzngs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Intended Audience :: End Users/Desktop",
     "Topic :: Multimedia :: Sound/Audio",
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: GNU General Public License v3",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
 dependencies = [
     "musicbrainzngs",


### PR DESCRIPTION
This project was using an incorrect trove classifier for GPLv3 (`License :: OSI Approved :: GNU General Public License v3` instead of `License :: OSI Approved :: GNU General Public License v3 (GPLv3)`)¹, which was leading to build failures with non-isolated builds. We could update just this classifier, however license trove classifiers are now deprecated, and the modern way of declaring licenses is though SPDX expressions² ³.

- Replace the deprecated `license = {file = "LICENSE"}` with a plain SPDX expression
- Add an explicit `license-files` entry to make sure it's included in builds
- Drop the now-redundant license trove classifier

[1] https://pypi.org/classifiers/#:~:text=GPLv3
[2] https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files
[3] https://peps.python.org/pep-0639/