### PR TITLE
Update dockerfile to trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:trixie
 ARG optical_gid
 ARG uid=1000
 
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     sox \
     swig \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
-    && pip3 --no-cache-dir install pycdio==2.1.0 discid
+    && pip3 --no-cache-dir install --break-system-packages pycdio==2.1.0 discid
 
 # libcdio-paranoia / libcdio-utils are wrongfully packaged in Debian, thus built manually
 # see https://github.com/whipper-team/whipper/pull/237#issuecomment-367985625

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 # libcdio-paranoia / libcdio-utils are wrongfully packaged in Debian, thus built manually
 # see https://github.com/whipper-team/whipper/pull/237#issuecomment-367985625
-ENV LIBCDIO_VERSION 2.1.0
+ENV LIBCDIO_VERSION=2.1.0
 RUN curl -o - "https://ftp.gnu.org/gnu/libcdio/libcdio-${LIBCDIO_VERSION}.tar.bz2" | tar jxf - \
     && cd libcdio-${LIBCDIO_VERSION} \
     && autoreconf -fi \
@@ -42,7 +42,7 @@ RUN curl -o - "https://ftp.gnu.org/gnu/libcdio/libcdio-${LIBCDIO_VERSION}.tar.bz
     && rm -rf libcdio-${LIBCDIO_VERSION}
 
 # Install cd-paranoia from tarball
-ENV LIBCDIO_PARANOIA_VERSION 10.2+2.0.1
+ENV LIBCDIO_PARANOIA_VERSION=10.2+2.0.1
 RUN curl -o - "https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-${LIBCDIO_PARANOIA_VERSION}.tar.bz2" | tar jxf - \
     && cd libcdio-paranoia-${LIBCDIO_PARANOIA_VERSION} \
     && autoreconf -fi \


### PR DESCRIPTION
My motivation for this is was that the version of `musicbrainzngs` provided by the package in debian:buster was less that 0.7, causing this warning to appear:

```
WARNING:whipper.command.main:Parameter 'use_https' is missing in versions of musicbrainzngs < 0.7. This means whipper will only be able to communicate with the configured MusicBrainz server ('musicbrainz.org') over plain HTTP. If a custom server which speaks HTTPS only has been declared, a suitable version of the musicbrainzngs module will be needed to make it work in whipper.
```

The version in trixie (current stable) is 0.7.1 (most recent version) so this issue no longer occurs. buster also reached end of life in [2022](https://www.debian.org/releases/buster/), so prob best to update.