### PR TITLE
Dockerfile: Fix cdrdao version detection & discid issues with trixie update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN pip install -U setuptools discid --break-system-packages
 # install whipper
 RUN mkdir /whipper
 COPY . /whipper/
-RUN cd /whipper && python3 setup.py install \
+RUN cd /whipper && pip install . --break-system-packages \
     && rm -rf /whipper \
     && whipper -v
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,9 @@ RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment \
     && locale-gen en_US.UTF-8
 
 # Trixie-shipped setuptools doesn't work, need to upgrade...
-RUN pip install -U setuptools discid --break-system-packages
+# Pin setuptools_scm as versions 10>= require packaging>=26.2 which conflicts with
+# the version from debian.
+RUN pip install -U setuptools discid "setuptools_scm<10" --break-system-packages
 
 # install whipper
 RUN mkdir /whipper

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment \
     && locale-gen en_US.UTF-8
 
 # Trixie-shipped setuptools doesn't work, need to upgrade...
-RUN pip install -U setuptools --break-system-packages
+RUN pip install -U setuptools discid --break-system-packages
 
 # install whipper
 RUN mkdir /whipper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "musicbrainzngs",
     "mutagen",
     "pycdio",
-    "PyGObject",
     "ruamel.yaml",
     "setuptools_scm",
     "discid",

--- a/whipper/program/cdrdao.py
+++ b/whipper/program/cdrdao.py
@@ -184,7 +184,7 @@ def version():
         logger.warning("cdrdao version detection failed: "
                        "return code is %s", cdrdao.returncode)
         return None
-    m = re.compile(r'^Cdrdao version (?P<version>.*)').search(
+    m = re.compile(r'^Cdrdao version (?P<version>\S+)').search(
         err.decode('utf-8'))
     if not m:
         logger.warning("cdrdao version detection failed: "


### PR DESCRIPTION
When I tested #668, I ran into the issues reported there and an issue with the python `discid` package not being installed.

This fixes those issues as follows:
* Change the version detection to break at the first space, rather than include everything after the version number as well
* Re-add the `discid` pip package. I don't believe there is a debian package, at least not that I could find.
* Run `pip install .` rather than `setup.py` directly to fix the 0.0.0 version issue
  * Remove unused `PyGObject` that was causing that to fail

I was able to rip a CD with this branch