### PR TITLE
Add --no-htoa option to skip Hidden Track One Audio ripping

### DIFF
--- a/man/whipper-cd-rip.rst
+++ b/man/whipper-cd-rip.rst
@@ -73,6 +73,10 @@ Options
 |     continue ripping further tracks instead of giving up if a track can't be
 |     ripped
 
+| **--no-htoa**
+|     don't rip Hidden Track One Audio (HTOA) even when it's detected; useful
+|     on drives that read the pregap very slowly
+
 Template schemes
 ================
 

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -326,6 +326,12 @@ Log files will log the path to tracks relative to this directory.
                                  help="continue ripping further tracks "
                                  "instead of giving up if a track "
                                  "can't be ripped")
+        self.parser.add_argument('--no-htoa',
+                                 action="store_true", dest="no_htoa",
+                                 help="don't rip Hidden Track One Audio "
+                                 "(HTOA) even when it's detected; useful on "
+                                 "drives that read the pregap very slowly",
+                                 default=False)
 
     def handle_arguments(self):
         self.options.output_directory = os.path.expanduser(
@@ -548,7 +554,10 @@ Log files will log the path to tracks relative to this directory.
             start, stop = htoa
             logger.info('found Hidden Track One Audio from frame %d to %d',
                         start, stop)
-            _ripIfNotRipped(0)
+            if self.options.no_htoa:
+                logger.info('skipping Hidden Track One Audio (--no-htoa)')
+            else:
+                _ripIfNotRipped(0)
 
         for i, track in enumerate(self.itable.tracks):
             # FIXME: rip data tracks differently


### PR DESCRIPTION
## Summary

Adds a `--no-htoa` option to `whipper cd rip` that skips ripping Hidden Track
One Audio (HTOA) even when it is detected.

## Motivation

On some drives, reading the pregap where HTOA lives is extremely slow, so a rip
that detects HTOA stalls on "track 0" and makes little to no progress —
effectively never finishing. This has been reported in #281 (rip stuck at
"track 0 of N", 0%) and is related to the drive-dependent pregap-reading
behaviour in #75. There is currently no way to opt out of HTOA ripping, so the
only workaround is to use a different drive or ripper for those discs.

`--no-htoa` lets users skip HTOA on such drives while still ripping the rest of
the disc normally. It defaults to off, so existing behaviour is unchanged
unless the flag is passed.

## Behaviour

When HTOA is detected and `--no-htoa` is given, whipper logs that it is skipping
it and continues straight to track 1:

    INFO:whipper.command.cd:found Hidden Track One Audio from frame 0 to 17481
    INFO:whipper.command.cd:skipping Hidden Track One Audio (--no-htoa)

Without the flag, behaviour is unchanged (HTOA is ripped as before).

## Testing

- Full test suite passes: `python3 -m unittest discover` → `Ran 117 tests ... OK`.
- Manually verified on a disc with HTOA: without `--no-htoa` the rip stalls
  indefinitely on "track 0"; with the flag it logs the skip, rips all remaining
  tracks, and they AccurateRip-verify clean.

I did not add an automated test for the flag itself: the option only gates the
HTOA branch inside `Rip.rip()`, which drives the full cdparanoia pipeline and
has no existing unit-test harness (no rip-flow or rip-option is currently
covered). Happy to add coverage if you can point me at the preferred approach.

## Docs

`man/whipper-cd-rip.rst` documents the new option. `CHANGELOG.md` is left
untouched as it is generated at release time.

Signed-off-by: Mirko Köster <git@mirkokoester.de>
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
