### PR TITLE
Support multiple countries in MusicBrainz lookup

### DIFF
--- a/man/whipper-cd-info.rst
+++ b/man/whipper-cd-info.rst
@@ -29,7 +29,9 @@ Options
 |     Prompt if there are multiple matching releases
 
 | **-c** *<COUNTRY>* | **--country** *<COUNTRY>*
-|     Filter releases by country
+|     Filter releases by country; specify multiple times or a
+      comma-separated list of countries to accept releases from multiple
+      countries. See https://musicbrainz.org/doc/Release/Country for abbreviations.
 
 
 See Also

--- a/man/whipper-cd-rip.rst
+++ b/man/whipper-cd-rip.rst
@@ -29,7 +29,9 @@ Options
 |     Prompt if there are multiple matching releases
 
 | **-c** *<COUNTRY>* | **--country** *<COUNTRY>*
-|     Filter releases by country
+|     Filter releases by country; specify multiple times or a
+      comma-separated list of countries to accept releases from multiple
+      countries. See https://musicbrainz.org/doc/Release/Country for abbreviations.
 
 | **-L** *<LOGGER<* | **--logger** *<LOGGER>*
 |     Logger to use

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -87,7 +87,8 @@ class _CD(BaseCommand):
                             help="Prompt if there are multiple "
                             "matching releases")
         parser.add_argument('-c', '--country',
-                            action="store", dest="country",
+                            action="extend", dest="country",
+                            type=lambda arg: (c.strip() for c in arg.split(",")),
                             help="Filter releases by country")
 
     def do(self):
@@ -122,7 +123,7 @@ class _CD(BaseCommand):
         self.program.metadata = (
             self.program.getMusicBrainz(self.ittoc, self.mbdiscid,
                                         release=self.options.release_id,
-                                        country=self.options.country,
+                                        countries=self.options.country,
                                         prompt=self.options.prompt)
         )
 

--- a/whipper/common/mbngs.py
+++ b/whipper/common/mbngs.py
@@ -232,7 +232,7 @@ def _getPerformers(recording):
     return sorted(performers)  # convert to list: mutagen doesn't support set
 
 
-def _getMetadata(release, discid=None, country=None):
+def _getMetadata(release, discid=None, countries=None):
     """
     Get disc metadata based upon the provided release id.
 
@@ -248,8 +248,8 @@ def _getMetadata(release, discid=None, country=None):
 
     assert release['id'], 'Release does not have an id'
 
-    if 'country' in release and country and release['country'] != country:
-        logger.warning('%r was not released in %r', release, country)
+    if 'country' in release and countries and release['country'] not in countries:
+        logger.warning('%r was not released in %r', release, countries)
         return None
 
     discMD = DiscMetadata()
@@ -362,7 +362,7 @@ def _getMetadata(release, discid=None, country=None):
     return discMD
 
 
-def getReleaseMetadata(release_id, discid=None, country=None, record=False):
+def getReleaseMetadata(release_id, discid=None, countries=None, record=False):
     """
     Return a DiscMetadata object based on MusicBrainz Release ID and Disc ID.
 
@@ -394,14 +394,14 @@ def getReleaseMetadata(release_id, discid=None, country=None, record=False):
     releaseDetail = res['release']
     formatted = json.dumps(releaseDetail, sort_keys=False, indent=4)
     logger.debug('release %s', formatted)
-    return _getMetadata(releaseDetail, discid, country)
+    return _getMetadata(releaseDetail, discid, countries)
 
 
 # see http://bugs.musicbrainz.org/browser/python-musicbrainz2/trunk/examples/
 #     ripper.py
 
 
-def musicbrainz(discid, country=None, record=False):
+def musicbrainz(discid, countries=None, record=False):
     """
     Get a list of DiscMetadata objects for the given MusicBrainz disc id.
 
@@ -444,7 +444,7 @@ def musicbrainz(discid, country=None, record=False):
             logger.debug('result %s: artist %r, title %r', formatted,
                          release['artist-credit-phrase'], release['title'])
 
-            md = getReleaseMetadata(release['id'], discid, country, record)
+            md = getReleaseMetadata(release['id'], discid, countries, record)
             if md:
                 logger.debug('duration %r', md.duration)
                 ret.append(md)

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -279,7 +279,7 @@ class Program:
 
         return None
 
-    def getMusicBrainz(self, ittoc, mbdiscid, release=None, country=None,
+    def getMusicBrainz(self, ittoc, mbdiscid, release=None, countries=None,
                        prompt=False):
         """
         Fetch MusicBrainz's metadata for the given MusicBrainz disc id.
@@ -309,7 +309,7 @@ class Program:
         for _ in range(0, 4):
             try:
                 metadatas = mbngs.musicbrainz(mbdiscid,
-                                              country=country,
+                                              countries=countries,
                                               record=self._record)
                 break
             except mbngs.NotFoundException as e:


### PR DESCRIPTION
Instead of specifying a single country via `--country` on the command line, support multiple `--country` options or a comma-separated list of countries.

Resolves #639.