### PR TITLE
Add config options for cover art size and filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,9 @@ output_directory = ~/My Music
 # Do not add inline comments with an unescaped '%' character (else an 'InterpolationSyntaxError' will occur).
 track_template = new/%%A/%%y - %%d/%%t - %%n
 disc_template =  new/%%A/%%y - %%d/%%A - %%d
+# Note: accepted values are 0, 250, 500, and 1200
+cover_art_size = 1200
+cover_art_filename = folder.jpg
 # ...
 ```
 

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -314,6 +314,18 @@ Log files will log the path to tracks relative to this directory.
                                  "complete option values respectively",
                                  choices=['file', 'embed', 'complete'],
                                  default=None)
+        self.parser.add_argument('--cover-art-size',
+                                 action="store", dest="cover_art_size",
+                                 help="size of cover art to fetch. Valid values are 0, 250, 500, and 1200. "
+                                      "Default is 500. When set to 0, the cover art will be fetched in the original "
+                                      "size.",
+                                 type=int,
+                                 choices=[0, 250, 500, 1200],
+                                 default=500)
+        self.parser.add_argument('--cover-art-filename',
+                                 action="store", dest="cover_art_filename",
+                                 help="name of cover art file to fetch",
+                                 default='cover.jpg')
         self.parser.add_argument('-r', '--max-retries',
                                  action="store", dest="max_retries",
                                  help="number of rip attempts before giving "
@@ -397,7 +409,9 @@ Log files will log the path to tracks relative to this directory.
             if getattr(self.program.metadata, "mbid", None) is not None:
                 self.coverArtPath = self.program.getCoverArt(
                                         dirname,
-                                        self.program.metadata.mbid)
+                                        self.program.metadata.mbid,
+                                        filename=self.options.cover_art_filename,
+                                        size=self.options.cover_art_size)
             else:
                 logger.warning("the cover art option '%s' won't be honored "
                                "because disc metadata isn't available",

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -513,7 +513,7 @@ class Program:
         return start, stop
 
     @staticmethod
-    def getCoverArt(path, release_id):
+    def getCoverArt(path, release_id, filename='cover.jpg', size=500):
         """
         Get cover art image from Cover Art Archive.
 
@@ -521,14 +521,18 @@ class Program:
         :type  path: str
         :param release_id: a release id (self.program.metadata.mbid)
         :type  release_id: str
+        :param filename: filename to store the image as
+        :type  filename: str
+        :param size: size of the image to fetch (0, 250, 500, 1200)
+        :type  size: int
         :returns: path to the downloaded cover art, else `None`
         :rtype: str or None
         """
-        cover_art_path = os.path.join(path, 'cover.jpg')
+        cover_art_path = os.path.join(path, filename)
 
         logger.debug('fetching cover art for release: %r', release_id)
         try:
-            data = musicbrainzngs.get_image_front(release_id, 500)
+            data = musicbrainzngs.get_image_front(release_id, size)
         except musicbrainzngs.WebServiceError as e:
             logger.error('error fetching cover art: %r', e)
             return


### PR DESCRIPTION
The change is backwards compatible and the defaults are still the same.